### PR TITLE
feat: add config customization support

### DIFF
--- a/src/Common/ThemeGetter.cs
+++ b/src/Common/ThemeGetter.cs
@@ -1,0 +1,35 @@
+﻿namespace TailwindMerge.Common;
+
+/// <summary>
+/// Represents a method that retrieves an array of objects from a theme based on a specified key.
+/// </summary>
+/// <param name="theme">The theme to retrieve values from.</param>
+/// <returns>An array of objects associated with the specified key in the theme.</returns>
+public delegate object[] ThemeGetter( Dictionary<string, object[]> theme );
+
+/// <summary>
+/// Provides utility method for working with theme configurations.
+/// </summary>
+public static class ThemeUtility
+{
+    /// <summary>
+    /// Creates a <see cref="ThemeGetter"/> delegate that retrieves values from a theme based on the specified key.
+    /// </summary>
+    /// <param name="key">The key to use for retrieving values from the theme.</param>
+    /// <returns>A <see cref="ThemeGetter"/>.</returns>
+    public static ThemeGetter FromTheme( string key )
+    {
+        ThemeGetter themeGetter = ( theme ) =>
+        {
+            if( theme.TryGetValue( key, out var value ) )
+            {
+                return value;
+            }
+
+            return [];
+        };
+
+        return themeGetter;
+    }
+}
+

--- a/src/Common/Validators.cs
+++ b/src/Common/Validators.cs
@@ -3,73 +3,115 @@ using System.Text.RegularExpressions;
 
 namespace TailwindMerge.Common;
 
-internal static partial class Validators
+/// <summary>
+/// Provides a set of validation functions for different class name parts.
+/// </summary>
+public static partial class Validators
 {
-    private static HashSet<string> _stringLengths = ["px", "full", "screen"];
-    private static HashSet<string> _sizeLabels = ["length", "size", "percentage"];
-    private static HashSet<string> _imageLabels = ["image", "url"];
+    private static readonly HashSet<string> _stringLengths = ["px", "full", "screen"];
+    private static readonly HashSet<string> _sizeLabels = ["length", "size", "percentage"];
+    private static readonly HashSet<string> _imageLabels = ["image", "url"];
 
-    internal static Func<string, bool> IsLength = ( value ) =>
+    /// <summary>
+    /// Validates whether a string represents a length value.
+    /// </summary>
+    public static bool IsLength( string value )
     {
-        return IsNumber!( value ) || _stringLengths.Contains( value ) || FractionRegex().IsMatch( value );
-    };
+        return IsNumber( value ) || _stringLengths.Contains( value ) || FractionRegex().IsMatch( value );
+    }
 
-    internal static Func<string, bool> IsArbitraryLength = ( value ) =>
+    /// <summary>
+    /// Validates whether a string represents an arbitrary length value.
+    /// </summary>
+    public static bool IsArbitraryLength( string value )
     {
         return GetIsArbitraryValue( value, "length", IsLengthOnly );
-    };
+    }
 
-    internal static Func<string, bool> IsNumber = ( value ) =>
+    /// <summary>
+    /// Validates whether a string represents a number.
+    /// </summary>
+    public static bool IsNumber( string value )
     {
         return !string.IsNullOrEmpty( value ) && double.TryParse( value, CultureInfo.InvariantCulture, out _ );
-    };
+    }
 
-    internal static Func<string, bool> IsInteger = ( value ) =>
+    /// <summary>
+    /// Validates whether a string represents an integer.
+    /// </summary>
+    public static bool IsInteger( string value )
     {
         return !string.IsNullOrEmpty( value ) && int.TryParse( value, out _ );
-    };
+    }
 
-    internal static Func<string, bool> IsPercent = ( value ) =>
+    /// <summary>
+    /// Validates whether a string represents a percentage.
+    /// </summary>
+    public static bool IsPercent( string value )
     {
         return value.EndsWith( '%' ) && IsNumber( value[..^1] );
-    };
+    }
 
-    internal static Func<string, bool> IsArbitraryNumber = ( value ) =>
+    /// <summary>
+    /// Validates whether a string represents an arbitrary number.
+    /// </summary>
+    public static bool IsArbitraryNumber( string value )
     {
         return GetIsArbitraryValue( value, "number", IsNumber );
-    };
+    }
 
-    internal static Func<string, bool> IsTshirtSize = ( value ) =>
+    /// <summary>
+    /// Validates whether a string represents a t-shirt size value.
+    /// </summary>
+    public static bool IsTshirtSize( string value )
     {
         return TshirtUnitRegex().IsMatch( value );
-    };
+    }
 
-    internal static Func<string, bool> IsArbitraryValue = ( value ) =>
+    /// <summary>
+    /// Validates whether a string represents an arbitrary value.
+    /// </summary>
+    public static bool IsArbitraryValue( string value )
     {
         return ArbitraryValueRegex().IsMatch( value );
-    };
+    }
 
-    internal static Func<string, bool> IsArbitrarySize = ( value ) =>
+    /// <summary>
+    /// Validates whether a string represents an arbitrary size.
+    /// </summary>
+    public static bool IsArbitrarySize( string value )
     {
         return GetIsArbitraryValue( value, _sizeLabels, IsNever );
-    };
+    }
 
-    internal static Func<string, bool> IsArbitraryPosition = ( value ) =>
+    /// <summary>
+    /// Validates whether a string represents an arbitrary position.
+    /// </summary>
+    public static bool IsArbitraryPosition( string value )
     {
         return GetIsArbitraryValue( value, "position", IsNever );
-    };
+    }
 
-    internal static Func<string, bool> IsArbitraryImage = ( value ) =>
+    /// <summary>
+    /// Validates whether a string represents an arbitrary image value.
+    /// </summary>
+    public static bool IsArbitraryImage( string value )
     {
         return GetIsArbitraryValue( value, _imageLabels, IsImage );
-    };
+    }
 
-    internal static Func<string, bool> IsArbitraryShadow = ( value ) =>
+    /// <summary>
+    /// Validates whether a string represents an arbitrary shadow value.
+    /// </summary>
+    public static bool IsArbitraryShadow( string value )
     {
         return GetIsArbitraryValue( value, string.Empty, IsShadow );
-    };
+    }
 
-    internal static Func<string, bool> IsAny = ( _ ) => true;
+    /// <summary>
+    /// Always returns true, indicating that any value is valid.
+    /// </summary>
+    public static bool IsAny( string value ) => true;
 
     private static bool GetIsArbitraryValue( string value, object label, Func<string, bool> testValue )
     {

--- a/src/Common/Validators.cs
+++ b/src/Common/Validators.cs
@@ -15,103 +15,103 @@ public static partial class Validators
     /// <summary>
     /// Validates whether a string represents a length value.
     /// </summary>
-    public static bool IsLength( string value )
+    public static Func<string, bool> IsLength => value =>
     {
         return IsNumber( value ) || _stringLengths.Contains( value ) || FractionRegex().IsMatch( value );
-    }
+    };
 
     /// <summary>
     /// Validates whether a string represents an arbitrary length value.
     /// </summary>
-    public static bool IsArbitraryLength( string value )
+    public static Func<string, bool> IsArbitraryLength => value =>
     {
         return GetIsArbitraryValue( value, "length", IsLengthOnly );
-    }
+    };
 
     /// <summary>
     /// Validates whether a string represents a number.
     /// </summary>
-    public static bool IsNumber( string value )
+    public static Func<string, bool> IsNumber => value =>
     {
         return !string.IsNullOrEmpty( value ) && double.TryParse( value, CultureInfo.InvariantCulture, out _ );
-    }
+    };
 
     /// <summary>
     /// Validates whether a string represents an integer.
     /// </summary>
-    public static bool IsInteger( string value )
+    public static Func<string, bool> IsInteger => value =>
     {
         return !string.IsNullOrEmpty( value ) && int.TryParse( value, out _ );
-    }
+    };
 
     /// <summary>
     /// Validates whether a string represents a percentage.
     /// </summary>
-    public static bool IsPercent( string value )
+    public static Func<string, bool> IsPercent => value =>
     {
         return value.EndsWith( '%' ) && IsNumber( value[..^1] );
-    }
+    };
 
     /// <summary>
     /// Validates whether a string represents an arbitrary number.
     /// </summary>
-    public static bool IsArbitraryNumber( string value )
+    public static Func<string, bool> IsArbitraryNumber => value =>
     {
         return GetIsArbitraryValue( value, "number", IsNumber );
-    }
+    };
 
     /// <summary>
     /// Validates whether a string represents a t-shirt size value.
     /// </summary>
-    public static bool IsTshirtSize( string value )
+    public static Func<string, bool> IsTshirtSize => value =>
     {
         return TshirtUnitRegex().IsMatch( value );
-    }
+    };
 
     /// <summary>
     /// Validates whether a string represents an arbitrary value.
     /// </summary>
-    public static bool IsArbitraryValue( string value )
+    public static Func<string, bool> IsArbitraryValue => value =>
     {
         return ArbitraryValueRegex().IsMatch( value );
-    }
+    };
 
     /// <summary>
     /// Validates whether a string represents an arbitrary size.
     /// </summary>
-    public static bool IsArbitrarySize( string value )
+    public static Func<string, bool> IsArbitrarySize => value =>
     {
         return GetIsArbitraryValue( value, _sizeLabels, IsNever );
-    }
+    };
 
     /// <summary>
     /// Validates whether a string represents an arbitrary position.
     /// </summary>
-    public static bool IsArbitraryPosition( string value )
+    public static Func<string, bool> IsArbitraryPosition => value =>
     {
         return GetIsArbitraryValue( value, "position", IsNever );
-    }
+    };
 
     /// <summary>
     /// Validates whether a string represents an arbitrary image value.
     /// </summary>
-    public static bool IsArbitraryImage( string value )
+    public static Func<string, bool> IsArbitraryImage => value =>
     {
         return GetIsArbitraryValue( value, _imageLabels, IsImage );
-    }
+    };
 
     /// <summary>
     /// Validates whether a string represents an arbitrary shadow value.
     /// </summary>
-    public static bool IsArbitraryShadow( string value )
+    public static Func<string, bool> IsArbitraryShadow => value =>
     {
         return GetIsArbitraryValue( value, string.Empty, IsShadow );
-    }
+    };
 
     /// <summary>
     /// Always returns true, indicating that any value is valid.
     /// </summary>
-    public static bool IsAny( string value ) => true;
+    public static Func<string, bool> IsAny => value => true;
 
     private static bool GetIsArbitraryValue( string value, object label, Func<string, bool> testValue )
     {

--- a/src/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Extensions/ServiceCollectionExtensions.cs
@@ -15,4 +15,15 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton<TwMerge>();
     }
+
+    /// <summary>
+    /// Registers a singleton instance of the <see cref="TwMerge"/> service with the given configuration options.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+    /// <param name="options">The delegate to configure the <see cref="TwMergeConfig"/> options.</param>
+    public static void AddTailwindMerge( this IServiceCollection services, Action<TwMergeConfig> options )
+    {
+        services.AddSingleton<TwMerge>();
+        services.Configure( options );
+    }
 }

--- a/src/Models/ClassGroup.cs
+++ b/src/Models/ClassGroup.cs
@@ -3,16 +3,10 @@
 /// <summary>
 /// Represents a group of CSS classes with associated metadata for the TailwindMerge utility.
 /// </summary>
-/// <param name="id">The unique identifier for the class group.</param>
 /// <param name="baseClassName">The base class name for the group.</param>
 /// <param name="definitions">An array of definitions associated with the class group.</param>
-public readonly struct ClassGroup( string id, string? baseClassName, object[] definitions )
+public readonly struct ClassGroup( string? baseClassName, object[] definitions )
 {
-    /// <summary>
-    /// Gets the unique identifier for the class group.
-    /// </summary>
-    public string Id { get; } = id;
-
     /// <summary>
     /// Gets the base class name for the group.
     /// </summary>
@@ -29,6 +23,6 @@ public readonly struct ClassGroup( string id, string? baseClassName, object[] de
     /// </summary>
     /// <param name="id">The unique identifier for the class group.</param>
     /// <param name="definitions">An array of definitions associated with the class group.</param>
-    public ClassGroup( string id, object[] definitions )
-        : this( id, null, definitions ) { }
+    public ClassGroup( object[] definitions )
+        : this( null, definitions ) { }
 }

--- a/src/Models/ClassGroup.cs
+++ b/src/Models/ClassGroup.cs
@@ -1,18 +1,44 @@
 ﻿namespace TailwindMerge.Models;
 
-internal readonly record struct ClassGroup(
+/// <summary>
+/// Represents a group of classes with associated metadata for the <see cref="TwMergeConfig"/>.
+/// </summary>
+/// <param name="Id">The unique identifier for the class group.</param>
+/// <param name="BaseClassName">The base class name of the class group.</param>
+/// <param name="ClassNameParts">An array of class name parts belonging to the group.</param>
+/// <param name="Validators">An array of validation functions for the class names.</param>
+public readonly record struct ClassGroup(
     string Id,
-    string? ClassName,
-    string[]? Items,
-    Func<string, bool>[]? Validators
-)
+    string? BaseClassName,
+    string[]? ClassNameParts,
+    Func<string, bool>[]? Validators )
 {
-    internal ClassGroup( string id, string[] items )
-        : this( id, null, items, null ) { }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClassGroup"/> struct 
+    /// with the specified <paramref name="id"/> and <paramref name="classNameParts"/>.
+    /// </summary>
+    /// <param name="id">The unique identifier for the class group.</param>
+    /// <param name="classNameParts">An array of class name parts belonging to the group.</param>
+    public ClassGroup( string id, string[] classNameParts )
+        : this( id, null, classNameParts, null ) { }
 
-    internal ClassGroup( string id, string className, string[] items )
-        : this( id, className, items, null ) { }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClassGroup"/> struct 
+    /// with the specified <paramref name="id"/>, <paramref name="baseClassName"/>, and <paramref name="classNameParts"/>.
+    /// </summary>
+    /// <param name="id">The unique identifier for the class group.</param>
+    /// <param name="baseClassName">The name of the class group.</param>
+    /// <param name="classNameParts">An array of class name parts belonging to the group.</param>
+    public ClassGroup( string id, string baseClassName, string[] classNameParts )
+        : this( id, baseClassName, classNameParts, null ) { }
 
-    internal ClassGroup( string id, string className, Func<string, bool>[] validators )
-        : this( id, className, null, validators ) { }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClassGroup"/> struct 
+    /// with the specified <paramref name="id"/>, <paramref name="baseClassName"/>, and <paramref name="validators"/>.
+    /// </summary>
+    /// <param name="id">The unique identifier for the class group.</param>
+    /// <param name="baseClassName">The name of the class group.</param>
+    /// <param name="validators">An array of validation functions for the class names.</param>
+    public ClassGroup( string id, string baseClassName, Func<string, bool>[] validators )
+        : this( id, baseClassName, null, validators ) { }
 }

--- a/src/Models/ClassGroup.cs
+++ b/src/Models/ClassGroup.cs
@@ -1,44 +1,34 @@
 ﻿namespace TailwindMerge.Models;
 
 /// <summary>
-/// Represents a group of classes with associated metadata for the <see cref="TwMergeConfig"/>.
+/// Represents a group of CSS classes with associated metadata for the TailwindMerge utility.
 /// </summary>
-/// <param name="Id">The unique identifier for the class group.</param>
-/// <param name="BaseClassName">The base class name of the class group.</param>
-/// <param name="ClassNameParts">An array of class name parts belonging to the group.</param>
-/// <param name="Validators">An array of validation functions for the class names.</param>
-public readonly record struct ClassGroup(
-    string Id,
-    string? BaseClassName,
-    string[]? ClassNameParts,
-    Func<string, bool>[]? Validators )
+/// <param name="id">The unique identifier for the class group.</param>
+/// <param name="baseClassName">The base class name for the group.</param>
+/// <param name="definitions">An array of definitions associated with the class group.</param>
+public readonly struct ClassGroup( string id, string? baseClassName, object[] definitions )
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ClassGroup"/> struct 
-    /// with the specified <paramref name="id"/> and <paramref name="classNameParts"/>.
+    /// Gets the unique identifier for the class group.
     /// </summary>
-    /// <param name="id">The unique identifier for the class group.</param>
-    /// <param name="classNameParts">An array of class name parts belonging to the group.</param>
-    public ClassGroup( string id, string[] classNameParts )
-        : this( id, null, classNameParts, null ) { }
+    public string Id { get; } = id;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ClassGroup"/> struct 
-    /// with the specified <paramref name="id"/>, <paramref name="baseClassName"/>, and <paramref name="classNameParts"/>.
+    /// Gets the base class name for the group.
     /// </summary>
-    /// <param name="id">The unique identifier for the class group.</param>
-    /// <param name="baseClassName">The name of the class group.</param>
-    /// <param name="classNameParts">An array of class name parts belonging to the group.</param>
-    public ClassGroup( string id, string baseClassName, string[] classNameParts )
-        : this( id, baseClassName, classNameParts, null ) { }
+    public string? BaseClassName { get; } = baseClassName;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ClassGroup"/> struct 
-    /// with the specified <paramref name="id"/>, <paramref name="baseClassName"/>, and <paramref name="validators"/>.
+    /// Gets an array of definitions associated with the class group.
+    /// </summary>
+    public object[] Definitions { get; } = definitions;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClassGroup"/> struct with the 
+    /// specified <paramref name="id"/> and <paramref name="definitions"/>.
     /// </summary>
     /// <param name="id">The unique identifier for the class group.</param>
-    /// <param name="baseClassName">The name of the class group.</param>
-    /// <param name="validators">An array of validation functions for the class names.</param>
-    public ClassGroup( string id, string baseClassName, Func<string, bool>[] validators )
-        : this( id, baseClassName, null, validators ) { }
+    /// <param name="definitions">An array of definitions associated with the class group.</param>
+    public ClassGroup( string id, object[] definitions )
+        : this( id, null, definitions ) { }
 }

--- a/src/Models/ClassNameNode.cs
+++ b/src/Models/ClassNameNode.cs
@@ -4,11 +4,9 @@ namespace TailwindMerge.Models;
 
 internal record ClassNameNode
 {
-    private List<ClassValidator>? _validators;
-
     internal string? ClassGroupId { get; set; }
     internal Dictionary<string, ClassNameNode>? Next { get; set; }
-    internal IReadOnlyCollection<ClassValidator>? Validators => _validators?.AsReadOnly();
+    internal List<ClassValidator>? Validators { get; set; }
 
     internal ClassNameNode AddNextNode( string className )
     {
@@ -33,7 +31,7 @@ internal record ClassNameNode
 
     internal void AddValidator( Func<string, bool> validator, string classGroupId )
     {
-        _validators ??= [];
-        _validators.Add( new ClassValidator( classGroupId, validator ) );
+        Validators ??= [];
+        Validators.Add( new ClassValidator( classGroupId, validator ) );
     }
 }

--- a/src/Models/ClassNameNode.cs
+++ b/src/Models/ClassNameNode.cs
@@ -13,8 +13,9 @@ internal record ClassNameNode
     internal ClassNameNode AddNextNode( string className )
     {
         var current = this;
+        var parts = className.Split( Constants.ClassNameSeparator, StringSplitOptions.RemoveEmptyEntries );
 
-        foreach( var part in className.Split( Constants.ClassNameSeparator, StringSplitOptions.RemoveEmptyEntries ) )
+        foreach( var part in parts )
         {
             current.Next ??= [];
 

--- a/src/Models/ExtendedConfig.cs
+++ b/src/Models/ExtendedConfig.cs
@@ -13,5 +13,15 @@ public class ExtendedConfig
     /// <summary>
     /// Gets or sets the class groups for the configuration extension.
     /// </summary>
-    public ClassGroup[]? ClassGroups { get; set; }
+    public Dictionary<string, ClassGroup>? ClassGroups { get; set; }
+
+    /// <summary>
+    /// Gets or sets the conflicting class groups for the configuration extension.
+    /// </summary>
+    public Dictionary<string, string[]>? ConflictingClassGroups { get; set; }
+
+    /// <summary>
+    /// Gets or sets the conflicting class group modifiers for the configuration extension.
+    /// </summary>
+    public Dictionary<string, string[]>? ConflictingClassGroupModifiers { get; set; }
 }

--- a/src/Models/ExtendedConfig.cs
+++ b/src/Models/ExtendedConfig.cs
@@ -1,0 +1,6 @@
+﻿namespace TailwindMerge.Models;
+
+public class ExtendedConfig
+{
+    public Dictionary<string, object[]>? Theme { get; set; }
+}

--- a/src/Models/ExtendedConfig.cs
+++ b/src/Models/ExtendedConfig.cs
@@ -1,6 +1,12 @@
 ﻿namespace TailwindMerge.Models;
 
+/// <summary>
+/// Represents the extended configuration for the TailwindMerge utility.
+/// </summary>
 public class ExtendedConfig
 {
+    /// <summary>
+    /// Gets or sets the theme configuration.
+    /// </summary>
     public Dictionary<string, object[]>? Theme { get; set; }
 }

--- a/src/Models/ExtendedConfig.cs
+++ b/src/Models/ExtendedConfig.cs
@@ -6,7 +6,12 @@
 public class ExtendedConfig
 {
     /// <summary>
-    /// Gets or sets the theme configuration.
+    /// Gets or sets the theme for the configuration extension.
     /// </summary>
     public Dictionary<string, object[]>? Theme { get; set; }
+
+    /// <summary>
+    /// Gets or sets the class groups for the configuration extension.
+    /// </summary>
+    public ClassGroup[]? ClassGroups { get; set; }
 }

--- a/src/TailwindMerge.csproj
+++ b/src/TailwindMerge.csproj
@@ -34,7 +34,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
 		<PackageReference Include="Planetarium.LruCacheNet" Version="1.2.0" />
 	</ItemGroup>
 

--- a/src/TwMerge.cs
+++ b/src/TwMerge.cs
@@ -2,6 +2,8 @@
 
 using LruCacheNet;
 
+using Microsoft.Extensions.Options;
+
 using TailwindMerge.Common;
 using TailwindMerge.Models;
 
@@ -17,11 +19,12 @@ public partial class TwMerge
     private readonly LruCache<string, string> _cache;
 
     /// <summary>
-    /// Initializes a new instance of <see cref="TwMerge" />.
+    /// Initializes a new instance of <see cref="TwMerge" /> with optional configuration options.
     /// </summary>
-    public TwMerge()
+    /// <param name="options">The configuration options.</param>
+    public TwMerge( IOptions<TwMergeConfig>? options = null )
     {
-        _config = TwMergeConfig.Default();
+        _config = options?.Value ?? TwMergeConfig.Default();
         _context = new TwMergeContext( _config );
         _cache = new LruCache<string, string>( _config.CacheSize );
     }

--- a/src/TwMergeConfig.cs
+++ b/src/TwMergeConfig.cs
@@ -8,1552 +8,6 @@ namespace TailwindMerge;
 /// </summary>
 public class TwMergeConfig
 {
-    private static readonly Func<string, bool>[] _any = [Validators.IsAny];
-    private static readonly Func<string, bool>[] _arbitraryValue = [Validators.IsArbitraryValue];
-    private static readonly Func<string, bool>[] _lengthAndArbitrary = [Validators.IsLength, Validators.IsArbitraryLength];
-    private static readonly Func<string, bool>[] _numberAndArbitrary = [Validators.IsNumber, Validators.IsArbitraryNumber];
-    private static readonly Func<string, bool>[] _numberAndArbitraryValue = [Validators.IsNumber, Validators.IsArbitraryValue];
-    private static readonly Func<string, bool>[] _integerAndArbitraryValue = [Validators.IsInteger, Validators.IsArbitraryValue];
-    private static readonly Func<string, bool>[] _tShirtSizeAndArbitraryValue = [Validators.IsTshirtSize, Validators.IsArbitraryValue];
-
-    private static readonly Func<string, bool>[] _spacings = [.. _lengthAndArbitrary, Validators.IsArbitraryValue];
-    private static readonly Func<string, bool>[] _gradientColorStopPositions = [Validators.IsPercent, Validators.IsArbitraryLength];
-
-    private static readonly string[] _auto = ["auto"];
-    private static readonly string[] _none = ["none"];
-    private static readonly string[] _autoAndNone = [.. _auto, .. _none];
-    private static readonly string[] _zeroAndEmpty = ["0", ""];
-
-    private static readonly string[] _align = ["start", "end", "center", "between", "around", "evenly", "stretch"];
-    private static readonly string[] _breaks = ["auto", "avoid", "all", "avoid-page", "page", "left", "right", "column"];
-    private static readonly string[] _lineStyles = ["solid", "dashed", "dotted", "double", "none"];
-    private static readonly string[] _overscroll = ["auto", "contain", "none"];
-    private static readonly string[] _overflow = ["auto", "hidden", "clip", "visible", "scroll"];
-    private static readonly string[] _blendModes = [
-        "normal",
-        "multiply",
-        "screen",
-        "overlay",
-        "darken",
-        "lighten",
-        "color-dodge",
-        "color-burn",
-        "hard-light",
-        "soft-light",
-        "difference",
-        "exclusion",
-        "hue",
-        "saturation",
-        "color",
-        "luminosity"
-    ];
-    private static readonly string[] _positions = [
-        "bottom",
-        "center",
-        "left",
-        "left-bottom",
-        "left-top",
-        "right",
-        "right-bottom",
-        "right-top",
-        "top"
-    ];
-
-    private static readonly (string[] Items, Func<string, bool>[] Validators) _borderWidth =
-        new( [""], _lengthAndArbitrary );
-
-    private static readonly (string[] Items, Func<string, bool>[] Validators) _borderRadius =
-        new( ["none", "full", ""], _tShirtSizeAndArbitraryValue );
-
-    private static readonly (string[] Items, Func<string, bool>[] Validators) _blur =
-        new( ["none", ""], _tShirtSizeAndArbitraryValue );
-
-    private static readonly ClassGroup[] _classGroups = [
-        /*
-         * Aspect Ratio
-         * See https://tailwindcss.com/docs/aspect-ratio
-         */
-        new ClassGroup( "aspect", "aspect", ["auto", "square", "video"], _arbitraryValue ),
-        /*
-         * Container
-         * See https://tailwindcss.com/docs/container
-         */
-        new ClassGroup( "container", ["container"] ),
-        /*
-         * Columns
-         * See https://tailwindcss.com/docs/columns
-         */
-        new ClassGroup( "columns", "columns", [Validators.IsTshirtSize] ),
-        /*
-         * Break After
-         * See https://tailwindcss.com/docs/break-after
-         */
-        new ClassGroup( "break-after", "break-after", _breaks ),
-        /*
-         * Break Before
-         * See https://tailwindcss.com/docs/break-before
-         */
-        new ClassGroup( "break-before", "break-before", _breaks ),
-        /*
-         * Break Inside
-         * See https://tailwindcss.com/docs/break-inside
-         */
-        new ClassGroup( "break-inside", "break-inside", ["auto", "avoid", "avoid-page", "avoid-column"] ),
-        /*
-         * Box Decoration Break
-         * See https://tailwindcss.com/docs/box-decoration-break
-         */
-        new ClassGroup( "box-decoration", "box-decoration", ["slice", "clone"] ),
-        /*
-         * Box Sizing
-         * See https://tailwindcss.com/docs/box-sizing
-         */
-        new ClassGroup( "box", "box", ["border", "content"] ),
-        /*
-         * Display
-         * See https://tailwindcss.com/docs/display
-         */
-        new ClassGroup( "display", [
-            "block",
-            "inline-block",
-            "inline",
-            "flex",
-            "inline-flex",
-            "table",
-            "inline-table",
-            "table-caption",
-            "table-cell",
-            "table-column",
-            "table-column-group",
-            "table-footer-group",
-            "table-header-group",
-            "table-row-group",
-            "table-row",
-            "flow-root",
-            "grid",
-            "inline-grid",
-            "contents",
-            "list-item",
-            "hidden"
-        ] ),
-        /*
-         * Floats
-         * See https://tailwindcss.com/docs/float
-         */
-        new ClassGroup( "float", "float", ["right", "left", "none", "start", "end"] ),
-        /*
-         * Clear
-         * See https://tailwindcss.com/docs/clear
-         */
-        new ClassGroup( "clear", "clear", ["left", "right", "both", "none", "start", "end"] ),
-        /*
-         * Isolation
-         * See https://tailwindcss.com/docs/isolation
-         */
-        new ClassGroup( "isolation", ["isolate", "isolation-auto"] ),
-        /*
-         * Object Fit
-         * See https://tailwindcss.com/docs/object-fit
-         */
-        new ClassGroup( "object-fit", "object", ["contain", "cover", "fill", "none", "scale-down"] ),
-        /*
-         * Object Position
-         * See https://tailwindcss.com/docs/object-position
-         */
-        new ClassGroup( "object-position", "object", _positions, _arbitraryValue ),
-        /*
-         * Overflow
-         * See https://tailwindcss.com/docs/overflow
-         */
-        new ClassGroup( "overflow", "overflow", _overflow ),
-        /*
-         * Overflow X
-         * See https://tailwindcss.com/docs/overflow
-         */
-        new ClassGroup( "overflow-x", "overflow-x", _overflow ),
-        /*
-         * Overflow Y
-         * See https://tailwindcss.com/docs/overflow
-         */
-        new ClassGroup( "overflow-y", "overflow-y", _overflow ),
-        /*
-         * Overscroll Behavior
-         * See https://tailwindcss.com/docs/overscroll-behavior
-         */
-        new ClassGroup( "overscroll", "overscroll", _overscroll ),
-        /*
-         * Overscroll Behavior X
-         * See https://tailwindcss.com/docs/overscroll-behavior
-         */
-        new ClassGroup( "overscroll-x", "overscroll-x", _overscroll ),
-        /*
-         * Overscroll Behavior Y
-         * See https://tailwindcss.com/docs/overscroll-behavior
-         */
-        new ClassGroup( "overscroll-y", "overscroll-y", _overscroll ),
-        /*
-         * Position
-         * See https://tailwindcss.com/docs/position
-         */
-        new ClassGroup( "position", ["static", "fixed", "absolute", "relative", "sticky"] ),
-        /*
-         * Top / Right / Bottom / Left
-         * See https://tailwindcss.com/docs/top-right-bottom-left
-         */
-        new ClassGroup( "inset", "inset", _auto, _spacings ),
-        /*
-         * Right / Left
-         * See https://tailwindcss.com/docs/top-right-bottom-left
-         */
-        new ClassGroup( "inset-x", "inset-x", _auto, _spacings ),
-        /*
-         * Top / Bottom
-         * See https://tailwindcss.com/docs/top-right-bottom-left
-         */
-        new ClassGroup( "inset-y", "inset-y", _auto, _spacings ),
-        /*
-         * Start
-         * See https://tailwindcss.com/docs/top-right-bottom-left
-         */
-        new ClassGroup( "start", "start", _auto, _spacings ),
-        /*
-         * End
-         * See https://tailwindcss.com/docs/top-right-bottom-left
-         */
-        new ClassGroup( "end", "end", _auto, _spacings ),
-        /*
-         * Top
-         * See https://tailwindcss.com/docs/top-right-bottom-left
-         */
-        new ClassGroup( "top", "top", _auto, _spacings ),
-        /*
-         * Right
-         * See https://tailwindcss.com/docs/top-right-bottom-left
-         */
-        new ClassGroup( "right", "right", _auto, _spacings ),
-        /*
-         * Bottom
-         * See https://tailwindcss.com/docs/top-right-bottom-left
-         */
-        new ClassGroup( "bottom", "bottom", _auto, _spacings ),
-        /*
-         * Left
-         * See https://tailwindcss.com/docs/top-right-bottom-left
-         */
-        new ClassGroup( "left", "left", _auto, _spacings ),
-        /*
-         * Visibility
-         * See https://tailwindcss.com/docs/visibility
-         */
-        new ClassGroup( "visibility", ["visible", "invisible", "collapse"] ),
-        /*
-         * Z-Index
-         * See https://tailwindcss.com/docs/z-index
-         */
-        new ClassGroup( "z", "z", _auto, _integerAndArbitraryValue ),
-        /*
-         * Flex Basis
-         * See https://tailwindcss.com/docs/flex-basis
-         */
-        new ClassGroup( "basis", "basis", _auto, _spacings ),
-        /*
-         * Flex Direction
-         * See https://tailwindcss.com/docs/flex-direction
-         */
-        new ClassGroup( "flex-direction", "flex", ["row", "row-reverse", "col", "col-reverse"] ),
-        /*
-         * Flex Wrap
-         * See https://tailwindcss.com/docs/flex-wrap
-         */
-        new ClassGroup( "flex-wrap", "flex", ["wrap", "wrap-reverse", "nowrap"] ),
-        /*
-         * Flex
-         * See https://tailwindcss.com/docs/flex
-         */
-        new ClassGroup( "flex", "flex", ["1", "auto", "initial", "none"], _arbitraryValue ),
-        /*
-         * Flex Grow
-         * See https://tailwindcss.com/docs/flex-grow
-         */
-        new ClassGroup( "grow", "grow", _zeroAndEmpty, _arbitraryValue ),
-        /*
-         * Flex Shrink
-         * See https://tailwindcss.com/docs/flex-shrink
-         */
-        new ClassGroup( "shrink", "shrink", _zeroAndEmpty, _arbitraryValue ),
-        /*
-         * Order
-         * See https://tailwindcss.com/docs/order
-         */
-        new ClassGroup( "order", "order", ["first", "last", "none"], _integerAndArbitraryValue ),
-        /*
-         * Grid Template Columns
-         * See https://tailwindcss.com/docs/grid-template-columns
-         */
-        new ClassGroup( "grid-cols", "grid-cols", _any ),
-        /*
-         * Grid Column Start / End
-         * See https://tailwindcss.com/docs/grid-column
-         */
-        new ClassGroup( "col-start-end", "col", _auto, _arbitraryValue ),
-        /*
-         * Grid Column Span
-         * See https://tailwindcss.com/docs/grid-column
-         */
-        new ClassGroup( "col-start-end", "col-span", ["full"], _numberAndArbitraryValue ),
-        /*
-         * Grid Column Start
-         * See https://tailwindcss.com/docs/grid-column
-         */
-        new ClassGroup( "col-start", "col-start", _auto, _numberAndArbitraryValue ),
-        /*
-         * Grid Column End
-         * See https://tailwindcss.com/docs/grid-column
-         */
-        new ClassGroup( "col-end", "col-end", _auto, _numberAndArbitraryValue ),
-        /*
-         * Grid Template Rows
-         * See https://tailwindcss.com/docs/grid-template-rows
-         */
-        new ClassGroup( "grid-rows", "grid-rows", _any ),
-        /*
-         * Grid Row Start / End
-         * See https://tailwindcss.com/docs/grid-row
-         */
-        new ClassGroup( "row-start-end", "row", _auto, _arbitraryValue ),
-        /*
-         * Grid Row Span
-         * See https://tailwindcss.com/docs/grid-row
-         */
-        new ClassGroup( "row-start-end", "row-span", _numberAndArbitraryValue ),
-        /*
-         * Grid Row Start
-         * See https://tailwindcss.com/docs/grid-row
-         */
-        new ClassGroup( "row-start", "row-start", _auto, _numberAndArbitraryValue ),
-        /*
-         * Grid Row End
-         * See https://tailwindcss.com/docs/grid-row
-         */
-        new ClassGroup( "row-end", "row-end", _auto, _numberAndArbitraryValue ),
-        /*
-         * Grid Auto Flow
-         * See https://tailwindcss.com/docs/grid-auto-flow
-         */
-        new ClassGroup( "grid-flow", "grid-flow", ["row", "col", "dense", "row-dense", "col-dense"] ),
-        /*
-         * Grid Auto Columns
-         * See https://tailwindcss.com/docs/grid-auto-columns
-         */
-        new ClassGroup( "auto-cols", "auto-cols", ["auto", "min", "max", "fr"], _arbitraryValue ),
-        /*
-         * Grid Auto Rows
-         * See https://tailwindcss.com/docs/grid-auto-rows
-         */
-        new ClassGroup( "auto-rows", "auto-rows", ["auto", "min", "max", "fr"], _arbitraryValue ),
-        /*
-         * Gap
-         * See https://tailwindcss.com/docs/gap
-         */
-        new ClassGroup( "gap", "gap", _spacings ),
-        /*
-         * Gap X
-         * See https://tailwindcss.com/docs/gap
-         */
-        new ClassGroup( "gap-x", "gap-x", _spacings ),
-        /*
-         * Gap Y
-         * See https://tailwindcss.com/docs/gap
-         */
-        new ClassGroup( "gap-y", "gap-y", _spacings ),
-        /*
-         * Justify Content
-         * See https://tailwindcss.com/docs/justify-content
-         */
-        new ClassGroup( "justify-content", "justify", ["normal", .. _align] ),
-        /*
-         * Justify Items
-         * See https://tailwindcss.com/docs/justify-items
-         */
-        new ClassGroup( "justify-items", "justify-items", ["start", "end", "center", "stretch"] ),
-        /*
-         * Justify Self
-         * See https://tailwindcss.com/docs/justify-self
-         */
-        new ClassGroup( "justify-self", "justify-self", ["auto", "start", "end", "center", "stretch"] ),
-        /*
-         * Align Content
-         * See https://tailwindcss.com/docs/align-content
-         */
-        new ClassGroup( "align-content", "content", ["normal", "baseline", .. _align] ),
-        /*
-         * Align Items
-         * See https://tailwindcss.com/docs/align-items
-         */
-        new ClassGroup( "align-items", "items", ["start", "end", "center", "baseline", "stretch"] ),
-        /*
-         * Align Self
-         * See https://tailwindcss.com/docs/align-self
-         */
-        new ClassGroup( "align-self", "self", ["auto", "start", "end", "center", "baseline", "stretch"] ),
-        /*
-         * Place Content
-         * See https://tailwindcss.com/docs/place-content
-         */
-        new ClassGroup( "place-content", "place-content", ["baseline", .. _align] ),
-        /*
-         * Place Items
-         * See https://tailwindcss.com/docs/place-items
-         */
-        new ClassGroup( "place-items", "place-items", ["start", "end", "center", "baseline", "stretch"] ),
-        /*
-         * Place Self
-         * See https://tailwindcss.com/docs/place-self
-         */
-        new ClassGroup( "place-self", "place-self", ["auto", "start", "end", "center", "stretch"] ),
-        /*
-         * Padding
-         * See https://tailwindcss.com/docs/padding
-         */
-        new ClassGroup( "p", "p", _spacings ),
-        /*
-         * Padding X
-         * See https://tailwindcss.com/docs/padding
-         */
-        new ClassGroup( "px", "px", _spacings ),
-        /*
-         * Padding Y
-         * See https://tailwindcss.com/docs/padding
-         */
-        new ClassGroup( "py", "py", _spacings ),
-        /*
-         * Padding Start
-         * See https://tailwindcss.com/docs/padding
-         */
-        new ClassGroup( "ps", "ps", _spacings ),
-        /*
-         * Padding End
-         * See https://tailwindcss.com/docs/padding
-         */
-        new ClassGroup( "pe", "pe", _spacings ),
-        /*
-         * Padding Top
-         * See https://tailwindcss.com/docs/padding
-         */
-        new ClassGroup( "pt", "pt", _spacings ),
-        /*
-         * Padding Right
-         * See https://tailwindcss.com/docs/padding
-         */
-        new ClassGroup( "pr", "pr", _spacings ),
-        /*
-         * Padding Bottom
-         * See https://tailwindcss.com/docs/padding
-         */
-        new ClassGroup( "pb", "pb", _spacings ),
-        /*
-         * Padding Left
-         * See https://tailwindcss.com/docs/padding
-         */
-        new ClassGroup( "pl", "pl", _auto, _spacings ),
-        /*
-         * Margin
-         * See https://tailwindcss.com/docs/margin
-         */
-        new ClassGroup( "m", "m", _auto, _spacings ),
-        /*
-         * Margin X
-         * See https://tailwindcss.com/docs/margin
-         */
-        new ClassGroup( "mx", "mx", _auto, _spacings ),
-        /*
-         * Margin Y
-         * See https://tailwindcss.com/docs/margin
-         */
-        new ClassGroup( "my", "my", _auto, _spacings ),
-        /*
-         * Margin Start
-         * See https://tailwindcss.com/docs/margin
-         */
-        new ClassGroup( "ms", "ms", _auto, _spacings ),
-        /*
-         * Margin End
-         * See https://tailwindcss.com/docs/margin
-         */
-        new ClassGroup( "me", "me", _auto, _spacings ),
-        /*
-         * Margin Top
-         * See https://tailwindcss.com/docs/margin
-         */
-        new ClassGroup( "mt", "mt", _auto, _spacings ),
-        /*
-         * Margin Right
-         * See https://tailwindcss.com/docs/margin
-         */
-        new ClassGroup( "mr", "mr", _auto, _spacings ),
-        /*
-         * Margin Bottom
-         * See https://tailwindcss.com/docs/margin
-         */
-        new ClassGroup( "mb", "mb", _auto, _spacings ),
-        /*
-         * Margin Left
-         * See https://tailwindcss.com/docs/margin
-         */
-        new ClassGroup( "ml", "ml", _auto, _spacings ),
-        /*
-         * Space Between X
-         * See https://tailwindcss.com/docs/space
-         */
-        new ClassGroup( "space-x", "space-x", _spacings ),
-        /*
-         * Space Between X Reverse
-         * See https://tailwindcss.com/docs/space
-         */
-        new ClassGroup( "space-x-reverse", ["space-x-reverse"] ),
-        /*
-         * Space Between Y
-         * See https://tailwindcss.com/docs/space
-         */
-        new ClassGroup( "space-y", "space-y", _spacings ),
-        /*
-         * Space Between Y Reverse
-         * See https://tailwindcss.com/docs/space
-         */
-        new ClassGroup( "space-y-reverse", ["space-y-reverse"] ),
-        /*
-         * Width
-         * See https://tailwindcss.com/docs/width
-         */
-        new ClassGroup( "w", "w", ["auto", "min", "max", "fit", "svw", "lvw", "dvw"], _spacings ),
-        /*
-         * Min-Width
-         * See https://tailwindcss.com/docs/min-width
-         */
-        new ClassGroup( "min-w", "min-w", ["min", "max", "fit"], _spacings ),
-        /*
-         * Max-Width
-         * See https://tailwindcss.com/docs/max-width
-         */
-        new ClassGroup( "max-w", "max-w", ["none", "full", "min", "max", "fit", "prose"], [.. _spacings, Validators.IsTshirtSize] ),
-        /*
-         * Max-Width Screen
-         * See https://tailwindcss.com/docs/max-width
-         */
-        new ClassGroup( "max-w", "max-w-screen", [Validators.IsTshirtSize] ),
-        /*
-         * Height
-         * See https://tailwindcss.com/docs/height
-         */
-        new ClassGroup( "h", "h", ["auto", "min", "max", "fit", "svh", "lvh", "dvh"], _spacings ),
-        /*
-         * Min-Height
-         * See https://tailwindcss.com/docs/min-height
-         */
-        new ClassGroup( "min-h", "min-h", ["min", "max", "fit", "svh", "lvh", "dvh"], _spacings ),
-        /*
-         * Max-Height
-         * See https://tailwindcss.com/docs/max-height
-         */
-        new ClassGroup( "max-h", "max-h", ["min", "max", "fit", "svh", "lvh", "dvh"], _spacings ),
-        /*
-         * Size
-         * See https://tailwindcss.com/docs/size
-         */
-        new ClassGroup( "size", "size", ["auto", "min", "max", "fit"], _spacings ),
-        /*
-         * Font Size
-         * See https://tailwindcss.com/docs/font-size
-         */
-        new ClassGroup( "font-size", "text", ["base"], [Validators.IsTshirtSize, Validators.IsArbitraryLength] ),
-        /*
-         * Font Smoothing
-         * See https://tailwindcss.com/docs/font-smoothing
-         */
-        new ClassGroup( "font-smoothing", ["antialiased", "subpixel-antialiased"] ),
-        /*
-         * Font Style
-         * See https://tailwindcss.com/docs/font-style
-         */
-        new ClassGroup( "font-style", ["italic", "not-italic"] ),
-        /*
-         * Font Weight
-         * See https://tailwindcss.com/docs/font-weight
-         */
-        new ClassGroup( "font-weight", "font", [
-            "thin",
-            "extralight",
-            "light",
-            "normal",
-            "medium",
-            "semibold",
-            "bold",
-            "extrabold",
-            "bold"],
-            [Validators.IsArbitraryNumber] ),
-        /*
-         * Font Family
-         * See https://tailwindcss.com/docs/font-family
-         */
-        new ClassGroup( "font-family", "font", _any ),
-        /*
-         * Font Variant Numeric
-         * See https://tailwindcss.com/docs/font-variant-numeric
-         */
-        new ClassGroup( "fvn-normal", ["normal-nums"] ),
-        /*
-         * Font Variant Numeric
-         * See https://tailwindcss.com/docs/font-variant-numeric
-         */
-        new ClassGroup( "fvn-ordinal", ["ordinal"] ),
-        /*
-         * Font Variant Numeric
-         * See https://tailwindcss.com/docs/font-variant-numeric
-         */
-        new ClassGroup( "fvn-slashed-zero", ["slashed-zero"] ),
-        /*
-         * Font Variant Numeric
-         * See https://tailwindcss.com/docs/font-variant-numeric
-         */
-        new ClassGroup( "fvn-figure", ["lining-nums", "oldstyle-nums"] ),
-        /*
-         * Font Variant Numeric
-         * See https://tailwindcss.com/docs/font-variant-numeric
-         */
-        new ClassGroup( "fvn-spacing", ["proportional-nums", "tabular-nums"] ),
-        /*
-         * Font Variant Numeric
-         * See https://tailwindcss.com/docs/font-variant-numeric
-         */
-        new ClassGroup( "fvn-fraction", ["diagonal-fractions", "stacked-fractions"] ),
-        /*
-         * Letter Spacing
-         * See https://tailwindcss.com/docs/letter-spacing
-         */
-        new ClassGroup( "tracking", "tracking", [
-            "tighter",
-            "tight",
-            "normal",
-            "wide",
-            "wider",
-            "widest"],
-            _arbitraryValue ),
-        /*
-         * Line Clamp
-         * See https://tailwindcss.com/docs/line-clamp
-         */
-        new ClassGroup( "line-clamp", "line-clamp", _none, _numberAndArbitrary ),
-        /*
-         * Line Height
-         * See https://tailwindcss.com/docs/line-height
-         */
-        new ClassGroup( "leading", "leading", [
-            "none",
-            "tight",
-            "snug",
-            "normal",
-            "relaxed",
-            "loose"],
-            [Validators.IsLength, Validators.IsArbitraryValue] ),
-        /*
-         * List Style Image
-         * See https://tailwindcss.com/docs/list-style-image
-         */
-        new ClassGroup( "list-image", "list-image", _none, _arbitraryValue ),
-        /*
-         * List Style Type
-         * See https://tailwindcss.com/docs/list-style-type
-         */
-        new ClassGroup( "list-style-type", "list", ["none", "disc", "decimal"], _arbitraryValue ),
-        /*
-         * List Style Position
-         * See https://tailwindcss.com/docs/list-style-position
-         */
-        new ClassGroup( "list-style-position", "list", ["inside", "outside"] ),
-        /*
-         * Placeholder Color
-         * See https://tailwindcss.com/docs/placeholder-color
-         */
-        new ClassGroup( "placeholder-color", "placeholder", _any ),
-        /*
-         * Text Alignment
-         * See https://tailwindcss.com/docs/text-align
-         */
-        new ClassGroup( "text-alignment", "text", ["left", "center", "right", "justify", "start", "end"] ),
-        /*
-         * Text Color
-         * See https://tailwindcss.com/docs/text-color
-         */
-        new ClassGroup( "text-color", "text", _any ),
-        /*
-         * Text Decoration
-         * See https://tailwindcss.com/docs/text-decoration
-         */
-        new ClassGroup( "text-decoration", ["underline", "overline", "line-through", "no-underline"] ),
-        /*
-         * Text Decoration Style
-         * See https://tailwindcss.com/docs/text-decoration-style
-         */
-        new ClassGroup( "text-decoration-style", "decoration", ["wavy", .. _lineStyles] ),
-        /*
-         * Text Decoration Color
-         * See https://tailwindcss.com/docs/text-decoration-color
-         */
-        new ClassGroup( "text-decoration-color", "decoration", _any ),
-        /*
-         * Text Decoration Thickness
-         * See https://tailwindcss.com/docs/text-decoration-thickness
-         */
-        new ClassGroup( "text-decoration-thickness", "decoration", ["auto", "from-font"], _lengthAndArbitrary ),
-        /*
-         * Text Underline Offset
-         * See https://tailwindcss.com/docs/text-underline-offset
-         */
-        new ClassGroup( "underline-offset", "underline-offset", _auto, [Validators.IsLength, Validators.IsArbitraryValue] ),
-        /*
-         * Text Transform
-         * See https://tailwindcss.com/docs/text-transform
-         */
-        new ClassGroup( "text-transform", ["uppercase", "lowercase", "capitalize", "normal-case"] ),
-        /*
-         * Text Overflow
-         * See https://tailwindcss.com/docs/text-overflow
-         */
-        new ClassGroup( "text-overflow", ["truncate", "text-ellipsis", "text-clip"] ),
-        /*
-         * Text Wrap
-         * See https://tailwindcss.com/docs/text-wrap
-         */
-        new ClassGroup( "text-wrap", "text", ["wrap", "nowrap", "balance", "pretty"] ),
-        /*
-         * Text Indent
-         * See https://tailwindcss.com/docs/text-indent
-         */
-        new ClassGroup( "indent", "indent", _spacings ),
-        /*
-         * Vertical Alignment
-         * See https://tailwindcss.com/docs/vertical-align
-         */
-        new ClassGroup( "vertical-align", "align", [
-            "baseline",
-            "top",
-            "middle",
-            "bottom",
-            "text-top",
-            "text-bottom",
-            "sub",
-            "super"],
-            _arbitraryValue ),
-        /*
-         * Whitespace
-         * See https://tailwindcss.com/docs/whitespace
-         */
-        new ClassGroup( "whitespace", "whitespace", [
-            "normal",
-            "nowrap",
-            "pre",
-            "pre-line",
-            "pre-wrap",
-            "break-spaces"] ),
-        /*
-         * Work Break
-         * See https://tailwindcss.com/docs/word-break
-         */
-        new ClassGroup( "break", "break", ["normal", "words", "all", "keep"] ),
-        /*
-         * Hyphens
-         * See https://tailwindcss.com/docs/hyphens
-         */
-        new ClassGroup( "hyphens", "hyphens", ["none", "manual", "auto"] ),
-        /*
-         * Content
-         * See https://tailwindcss.com/docs/content
-         */
-        new ClassGroup( "content", "content", _none, _arbitraryValue ),
-        /*
-         * Background Attachment
-         * See https://tailwindcss.com/docs/background-attachment
-         */
-        new ClassGroup( "bg-attachment", "bg", ["fixed", "local", "scroll"] ),
-        /*
-         * Background Clip
-         * See https://tailwindcss.com/docs/background-clip
-         */
-        new ClassGroup( "bg-clip", "bg-clip", ["border", "padding", "content", "text"] ),
-        /*
-         * Background Origin
-         * See https://tailwindcss.com/docs/background-origin
-         */
-        new ClassGroup( "bg-origin", "bg-origin", ["border", "padding", "content"] ),
-        /*
-         * Background Position
-         * See https://tailwindcss.com/docs/background-position
-         */
-        new ClassGroup( "bg-position", "bg", _positions, [Validators.IsArbitraryPosition] ),
-        /*
-         * Background Repeat
-         * See https://tailwindcss.com/docs/background-repeat
-         */
-        new ClassGroup( "bg-repeat", "bg", ["no-repeat"] ),
-        /*
-         * Background Repeat
-         * See https://tailwindcss.com/docs/background-repeat
-         */
-        new ClassGroup( "bg-repeat", "bg-repeat", ["", "x", "y", "round", "space"] ),
-        /*
-         * Background Size
-         * See https://tailwindcss.com/docs/background-size
-         */
-        new ClassGroup( "bg-size", "bg", ["auto", "cover", "contain"], [Validators.IsArbitrarySize] ),
-        /*
-         * Background Image
-         * See https://tailwindcss.com/docs/background-image
-         */
-        new ClassGroup( "bg-image", "bg", _none, [Validators.IsArbitraryImage] ),
-        /*
-         * Background Image Gradient To
-         * See https://tailwindcss.com/docs/background-image
-         */
-        new ClassGroup( "bg-image", "bg-gradient-to", ["t", "tr", "r", "br", "b", "bl", "l", "tl"] ),
-        /*
-         * Background Color
-         * See https://tailwindcss.com/docs/background-color
-         */
-        new ClassGroup( "bg-color", "bg", _any ),
-        /*
-         * Gradient Color Stops From Position
-         * See https://tailwindcss.com/docs/gradient-color-stops
-         */
-        new ClassGroup( "gradient-from-pos", "from", _gradientColorStopPositions ),
-        /*
-         * Gradient Color Stops Via Position
-         * See https://tailwindcss.com/docs/gradient-color-stops
-         */
-        new ClassGroup( "gradient-via-pos", "via", _gradientColorStopPositions ),
-        /*
-         * Gradient Color Stops To Position
-         * See https://tailwindcss.com/docs/gradient-color-stops
-         */
-        new ClassGroup( "gradient-to-pos", "to", _gradientColorStopPositions ),
-        /*
-         * Gradient Color Stops From
-         * See https://tailwindcss.com/docs/gradient-color-stops
-         */
-        new ClassGroup( "gradient-from", "from", _any ),
-        /*
-         * Gradient Color Stops Via
-         * See https://tailwindcss.com/docs/gradient-color-stops
-         */
-        new ClassGroup( "gradient-via", "via", _any ),
-        /*
-         * Gradient Color Stops To
-         * See https://tailwindcss.com/docs/gradient-color-stops
-         */
-        new ClassGroup( "gradient-to", "to", _any ),
-        /*
-         * Border Radius
-         * See https://tailwindcss.com/docs/border-radius
-         */
-        new ClassGroup( "rounded", "rounded", _borderRadius.Items, _borderRadius.Validators ),
-        /*
-         * Border Radius Start
-         * See https://tailwindcss.com/docs/border-radius
-         */
-        new ClassGroup( "rounded-s", "rounded-s", _borderRadius.Items, _borderRadius.Validators ),
-        /*
-         * Border Radius End
-         * See https://tailwindcss.com/docs/border-radius
-         */
-        new ClassGroup( "rounded-e", "rounded-e", _borderRadius.Items, _borderRadius.Validators ),
-        /*
-         * Border Radius Top
-         * See https://tailwindcss.com/docs/border-radius
-         */
-        new ClassGroup( "rounded-t", "rounded-t", _borderRadius.Items, _borderRadius.Validators ),
-        /*
-         * Border Radius Right
-         * See https://tailwindcss.com/docs/border-radius
-         */
-        new ClassGroup( "rounded-r", "rounded-r", _borderRadius.Items, _borderRadius.Validators ),
-        /*
-         * Border Radius Bottom
-         * See https://tailwindcss.com/docs/border-radius
-         */
-        new ClassGroup( "rounded-b", "rounded-b", _borderRadius.Items, _borderRadius.Validators ),
-        /*
-         * Border Radius Left
-         * See https://tailwindcss.com/docs/border-radius
-         */
-        new ClassGroup( "rounded-l", "rounded-l", _borderRadius.Items, _borderRadius.Validators ),
-        /*
-         * Border Radius Start Start
-         * See https://tailwindcss.com/docs/border-radius
-         */
-        new ClassGroup( "rounded-ss", "rounded-ss", _borderRadius.Items, _borderRadius.Validators ),
-        /*
-         * Border Radius Start End
-         * See https://tailwindcss.com/docs/border-radius
-         */
-        new ClassGroup( "rounded-se", "rounded-se", _borderRadius.Items, _borderRadius.Validators ),
-        /*
-         * Border Radius End End
-         * See https://tailwindcss.com/docs/border-radius
-         */
-        new ClassGroup( "rounded-ee", "rounded-ee", _borderRadius.Items, _borderRadius.Validators ),
-        /*
-         * Border Radius End Start
-         * See https://tailwindcss.com/docs/border-radius
-         */
-        new ClassGroup( "rounded-es", "rounded-es", _borderRadius.Items, _borderRadius.Validators ),
-        /*
-         * Border Radius Top Left
-         * See https://tailwindcss.com/docs/border-radius
-         */
-        new ClassGroup( "rounded-tl", "rounded-tl", _borderRadius.Items, _borderRadius.Validators ),
-        /*
-         * Border Radius Top Right
-         * See https://tailwindcss.com/docs/border-radius
-         */
-        new ClassGroup( "rounded-tr", "rounded-tr", _borderRadius.Items, _borderRadius.Validators ),
-        /*
-         * Border Radius Bottom Right
-         * See https://tailwindcss.com/docs/border-radius
-         */
-        new ClassGroup( "rounded-br", "rounded-br", _borderRadius.Items, _borderRadius.Validators ),
-        /*
-         * Border Radius Bottom Left
-         * See https://tailwindcss.com/docs/border-radius
-         */
-        new ClassGroup( "rounded-bl", "rounded-bl", _borderRadius.Items, _borderRadius.Validators ),
-        /*
-         * Border Width
-         * See https://tailwindcss.com/docs/border-width
-         */
-        new ClassGroup( "border-w", "border", _borderWidth.Items, _borderWidth.Validators ),
-        /*
-         * Border Width X
-         * See https://tailwindcss.com/docs/border-width
-         */
-        new ClassGroup( "border-w-x", "border-x", _borderWidth.Items, _borderWidth.Validators ),
-        /*
-         * Border Width Y
-         * See https://tailwindcss.com/docs/border-width
-         */
-        new ClassGroup( "border-w-y", "border-y", _borderWidth.Items, _borderWidth.Validators ),
-        /*
-         * Border Width Start
-         * See https://tailwindcss.com/docs/border-width
-         */
-        new ClassGroup( "border-w-s", "border-s", _borderWidth.Items, _borderWidth.Validators ),
-        /*
-         * Border Width End
-         * See https://tailwindcss.com/docs/border-width
-         */
-        new ClassGroup( "border-w-e", "border-e", _borderWidth.Items, _borderWidth.Validators ),
-        /*
-         * Border Width Top
-         * See https://tailwindcss.com/docs/border-width
-         */
-        new ClassGroup( "border-w-t", "border-t", _borderWidth.Items, _borderWidth.Validators ),
-        /*
-         * Border Width Right
-         * See https://tailwindcss.com/docs/border-width
-         */
-        new ClassGroup( "border-w-r", "border-r", _borderWidth.Items, _borderWidth.Validators ),
-        /*
-         * Border Width Bottom
-         * See https://tailwindcss.com/docs/border-width
-         */
-        new ClassGroup( "border-w-b", "border-b", _borderWidth.Items, _borderWidth.Validators ),
-        /*
-         * Border Width Left
-         * See https://tailwindcss.com/docs/border-width
-         */
-        new ClassGroup( "border-w-l", "border-l", _borderWidth.Items, _borderWidth.Validators ),
-        /*
-         * Border Style
-         * See https://tailwindcss.com/docs/border-style
-         */
-        new ClassGroup( "border-style", "border", ["hidden", .. _lineStyles] ),
-        /*
-         * Divide Width X
-         * See https://tailwindcss.com/docs/divide-width
-         */
-        new ClassGroup( "divide-x", "divide-x", _borderWidth.Items, _borderWidth.Validators ),
-        /*
-         * Divide Width X Reverse
-         * See https://tailwindcss.com/docs/divide-width
-         */
-        new ClassGroup( "divide-x-reverse", ["divide-x-reverse"] ),
-        /*
-         * Divide Width Y
-         * See https://tailwindcss.com/docs/divide-width
-         */
-        new ClassGroup( "divide-y", "divide-y", _borderWidth.Items, _borderWidth.Validators ),
-        /*
-         * Divide Width Y Reverse
-         * See https://tailwindcss.com/docs/divide-width
-         */
-        new ClassGroup( "divide-y-reverse", ["divide-y-reverse"] ),
-        /*
-         * Divide Style
-         * See https://tailwindcss.com/docs/divide-style
-         */
-        new ClassGroup( "divide-style", "divide", _lineStyles ),
-        /*
-         * Border Color
-         * See https://tailwindcss.com/docs/border-color
-         */
-        new ClassGroup( "border-color", "border", _any ),
-        /*
-         * Border Color X
-         * See https://tailwindcss.com/docs/border-color
-         */
-        new ClassGroup( "border-color-x", "border-x", _any ),
-        /*
-         * Border Color Y
-         * See https://tailwindcss.com/docs/border-color
-         */
-        new ClassGroup( "border-color-y", "border-y", _any ),
-        /*
-         * Border Color Top
-         * See https://tailwindcss.com/docs/border-color
-         */
-        new ClassGroup( "border-color-t", "border-t", _any ),
-        /*
-         * Border Color Right
-         * See https://tailwindcss.com/docs/border-color
-         */
-        new ClassGroup( "border-color-r", "border-r", _any ),
-        /*
-         * Border Color Bottom
-         * See https://tailwindcss.com/docs/border-color
-         */
-        new ClassGroup( "border-color-b", "border-b", _any ),
-        /*
-         * Border Color Left
-         * See https://tailwindcss.com/docs/border-color
-         */
-        new ClassGroup( "border-color-l", "border-l", _any ),
-        /*
-         * Divide Color
-         * See https://tailwindcss.com/docs/divide-color
-         */
-        new ClassGroup( "divide-color", "divide", _any ),
-        /*
-         * Outline Style
-         * See https://tailwindcss.com/docs/outline-style
-         */
-        new ClassGroup( "outline-style", "outline", ["", .. _lineStyles] ),
-        /*
-         * Outline Offset
-         * See https://tailwindcss.com/docs/outline-offset
-         */
-        new ClassGroup( "outline-offset", "outline-offset", _lengthAndArbitrary ),
-        /*
-         * Outline Width
-         * See https://tailwindcss.com/docs/outline-width
-         */
-        new ClassGroup( "outline-w", "outline", _lengthAndArbitrary ),
-        /*
-         * Outline Color
-         * See https://tailwindcss.com/docs/outline-color
-         */
-        new ClassGroup( "outline-color", "outline", _any ),
-        /*
-         * Ring Width
-         * See https://tailwindcss.com/docs/ring-width
-         */
-        new ClassGroup( "ring-w", "ring", [""], _lengthAndArbitrary ),
-        /*
-         * Ring Width Inset
-         * See https://tailwindcss.com/docs/ring-width
-         */
-        new ClassGroup( "ring-w-inset", ["ring-inset"] ),
-        /*
-         * Ring Color
-         * See https://tailwindcss.com/docs/ring-color
-         */
-        new ClassGroup( "ring-color", "ring", _any ),
-        /*
-         * Ring Offset Width
-         * See https://tailwindcss.com/docs/ring-offset-width
-         */
-        new ClassGroup( "ring-offset-w", "ring-offset", _lengthAndArbitrary ),
-        /*
-         * Ring Offset Color
-         * See https://tailwindcss.com/docs/ring-offset-color
-         */
-        new ClassGroup( "ring-offset-color", "ring-offset", _any ),
-        /*
-         * Shadow
-         * See https://tailwindcss.com/docs/shadow
-         */
-        new ClassGroup( "shadow", "shadow", ["", "inner", "none"], [Validators.IsTshirtSize, Validators.IsArbitraryShadow] ),
-        /*
-         * Shadow Color
-         * See https://tailwindcss.com/docs/shadow-color
-         */
-        new ClassGroup( "shadow-color", "shadow", _any ),
-        /*
-         * Opacity
-         * See https://tailwindcss.com/docs/opacity
-         */
-        new ClassGroup( "opacity", "opacity", _numberAndArbitrary ),
-        /*
-         * Mix Blend Mode
-         * See https://tailwindcss.com/docs/mix-blend-mode
-         */
-        new ClassGroup( "mix-blend", "mix-blend", ["plus-lighter", "plus-darker", .. _blendModes] ),
-        /*
-         * Background Blend Mode
-         * See https://tailwindcss.com/docs/mix-blend-mode
-         */
-        new ClassGroup( "bg-blend", "bg-blend", _blendModes ),
-        /*
-         * Blur
-         * See https://tailwindcss.com/docs/blur
-         */
-        new ClassGroup( "blur", "blur", _blur.Items, _blur.Validators ),
-        /*
-         * Brightness
-         * See https://tailwindcss.com/docs/brightness
-         */
-        new ClassGroup( "brightness", "brightness", _numberAndArbitrary ),
-        /*
-         * Contrast
-         * See https://tailwindcss.com/docs/contrast
-         */
-        new ClassGroup( "contrast", "contrast", _numberAndArbitrary ),
-        /*
-         * Drop Shadow
-         * See https://tailwindcss.com/docs/drop-shadow
-         */
-        new ClassGroup( "drop-shadow", "drop-shadow", ["none", ""], _tShirtSizeAndArbitraryValue ),
-        /*
-         * Grayscale
-         * See https://tailwindcss.com/docs/grayscale
-         */
-        new ClassGroup( "grayscale", "grayscale", _zeroAndEmpty, _arbitraryValue ),
-        /*
-         * Hue Rotate
-         * See https://tailwindcss.com/docs/hue-rotate
-         */
-        new ClassGroup( "hue-rotate", "hue-rotate", _numberAndArbitraryValue ),
-        /*
-         * Invert
-         * See https://tailwindcss.com/docs/invert
-         */
-        new ClassGroup( "invert", "invert", _zeroAndEmpty ),
-        /*
-         * Saturate
-         * See https://tailwindcss.com/docs/saturate
-         */
-        new ClassGroup( "saturate", "saturate", _numberAndArbitrary ),
-        /*
-         * Sepia
-         * See https://tailwindcss.com/docs/sepia
-         */
-        new ClassGroup( "sepia", "sepia", _zeroAndEmpty ),
-        /*
-         * Backdrop Blur
-         * See https://tailwindcss.com/docs/backdrop-blur
-         */
-        new ClassGroup( "backdrop-blur", "backdrop-blur", _blur.Items, _blur.Validators ),
-        /*
-         * Backdrop Brightness
-         * See https://tailwindcss.com/docs/backdrop-brightness
-         */
-        new ClassGroup( "backdrop-brightness", "backdrop-brightness", _numberAndArbitrary ),
-        /*
-         * Backdrop Contrast
-         * See https://tailwindcss.com/docs/backdrop-contrast
-         */
-        new ClassGroup( "backdrop-contrast", "backdrop-contrast", _numberAndArbitrary ),
-        /*
-         * Backdrop Grayscale
-         * See https://tailwindcss.com/docs/backdrop-grayscale
-         */
-        new ClassGroup( "backdrop-grayscale", "backdrop-grayscale", _zeroAndEmpty ),
-        /*
-         * Backdrop Hue Rotate
-         * See https://tailwindcss.com/docs/backdrop-hue-rotate
-         */
-        new ClassGroup( "backdrop-hue-rotate", "backdrop-hue-rotate", _numberAndArbitraryValue ),
-        /*
-         * Backdrop Invert
-         * See https://tailwindcss.com/docs/backdrop-invert
-         */
-        new ClassGroup( "backdrop-invert", "backdrop-invert", _zeroAndEmpty ),
-        /*
-         * Backdrop Opacity
-         * See https://tailwindcss.com/docs/backdrop-opacity
-         */
-        new ClassGroup( "backdrop-opacity", "backdrop-opacity", _numberAndArbitrary ),
-        /*
-         * Backdrop Saturate
-         * See https://tailwindcss.com/docs/backdrop-saturate
-         */
-        new ClassGroup( "backdrop-saturate", "backdrop-saturate", _numberAndArbitrary ),
-        /*
-         * Backdrop Sepia
-         * See https://tailwindcss.com/docs/backdrop-sepia
-         */
-        new ClassGroup( "backdrop-sepia", "backdrop-sepia", _zeroAndEmpty ),
-        /*
-         * Border Collapse
-         * See https://tailwindcss.com/docs/border-collapse
-         */
-        new ClassGroup( "border-collapse", "border", ["collapse", "separate"] ),
-        /*
-         * Border Spacing
-         * See https://tailwindcss.com/docs/border-spacing
-         */
-        new ClassGroup( "border-spacing", "border-spacing", _spacings ),
-        /*
-         * Border Spacing X
-         * See https://tailwindcss.com/docs/border-spacing
-         */
-        new ClassGroup( "border-spacing-x", "border-spacing-x", _spacings ),
-        /*
-         * Border Spacing Y
-         * See https://tailwindcss.com/docs/border-spacing
-         */
-        new ClassGroup( "border-spacing-y", "border-spacing-y", _spacings ),
-        /*
-         * Table Layout
-         * See https://tailwindcss.com/docs/table-layout
-         */
-        new ClassGroup( "table-layout", "table", ["auto", "fixed"] ),
-        /*
-         * Caption Side
-         * See https://tailwindcss.com/docs/caption-side
-         */
-        new ClassGroup( "caption", "caption", ["top", "bottom"] ),
-        /*
-         * Transition Property
-         * See https://tailwindcss.com/docs/transition-property
-         */
-        new ClassGroup( "transition", "transition", ["none", "all", "", "colors", "opacity", "shadow", "transform"], _arbitraryValue ),
-        /*
-         * Transition Duration
-         * See https://tailwindcss.com/docs/transition-duration
-         */
-        new ClassGroup( "duration", "duration", _numberAndArbitraryValue ),
-        /*
-         * Transition Timing Function
-         * See https://tailwindcss.com/docs/transition-timing-function
-         */
-        new ClassGroup( "ease", "ease", ["linear", "in", "out", "in-out"], _arbitraryValue ),
-        /*
-         * Transition Delay
-         * See https://tailwindcss.com/docs/transition-delay
-         */
-        new ClassGroup( "delay", "delay", _numberAndArbitraryValue ),
-        /*
-         * Animation
-         * See https://tailwindcss.com/docs/animation
-         */
-        new ClassGroup( "animate", "animate", ["none", "spin", "ping", "pulse", "bounce"], _arbitraryValue ),
-        /*
-         * Transform
-         * See https://tailwindcss.com/docs/transform
-         */
-        new ClassGroup( "transform", "transform", ["", "gpu", "none"] ),
-        /*
-         * Scale
-         * See https://tailwindcss.com/docs/scale
-         */
-        new ClassGroup( "scale", "scale", _numberAndArbitraryValue ),
-        /*
-         * Scale X
-         * See https://tailwindcss.com/docs/scale
-         */
-        new ClassGroup( "scale-x", "scale-x", _numberAndArbitraryValue ),
-        /*
-         * Scale Y
-         * See https://tailwindcss.com/docs/scale
-         */
-        new ClassGroup( "scale-y", "scale-y", _numberAndArbitraryValue ),
-        /*
-         * Rotate
-         * See https://tailwindcss.com/docs/rotate
-         */
-        new ClassGroup( "rotate", "rotate", _integerAndArbitraryValue ),
-        /*
-         * Translate X
-         * See https://tailwindcss.com/docs/translate
-         */
-        new ClassGroup( "translate-x", "translate-x", _numberAndArbitraryValue ),
-        /*
-         * Translate Y
-         * See https://tailwindcss.com/docs/translate
-         */
-        new ClassGroup( "translate-y", "translate-y", _numberAndArbitraryValue ),
-        /*
-         * Skew X
-         * See https://tailwindcss.com/docs/skew
-         */
-        new ClassGroup( "skew-x", "skew-x", _numberAndArbitraryValue ),
-        /*
-         * Skew Y
-         * See https://tailwindcss.com/docs/skew
-         */
-        new ClassGroup( "skew-y", "skew-y", _numberAndArbitraryValue ),
-        /*
-         * Transform Origin
-         * See https://tailwindcss.com/docs/transform-origin
-         */
-        new ClassGroup( "transform-origin", "origin", [
-            "center",
-            "top",
-            "top-right",
-            "right",
-            "bottom-right",
-            "bottom",
-            "bottom-left",
-            "left",
-            "top-left"],
-            _arbitraryValue ),
-        /*
-         * Accent
-         * See https://tailwindcss.com/docs/accent
-         */
-        new ClassGroup( "accent", "accent", _auto, _any ),
-        /*
-         * Appearance
-         * See https://tailwindcss.com/docs/appearance
-         */
-        new ClassGroup( "appearance", "appearance", _autoAndNone ),
-        /*
-         * Cursor
-         * See https://tailwindcss.com/docs/cursor
-         */
-        new ClassGroup( "cursor", "cursor", [
-            "auto",
-            "default",
-            "pointer",
-            "wait",
-            "text",
-            "move",
-            "help",
-            "not-allowed",
-            "none",
-            "context-menu",
-            "progress",
-            "cell",
-            "crosshair",
-            "vertical-text",
-            "alias",
-            "copy",
-            "no-drop",
-            "grab",
-            "grabbing",
-            "all-scroll",
-            "col-resize",
-            "row-resize",
-            "n-resize",
-            "e-resize",
-            "s-resize",
-            "w-resize",
-            "ne-resize",
-            "nw-resize",
-            "se-resize",
-            "sw-resize",
-            "ew-resize",
-            "ns-resize",
-            "nesw-resize",
-            "nwse-resize",
-            "zoom-in",
-            "zoom-out"],
-            _arbitraryValue ),
-        /*
-         * Caret Color
-         * See https://tailwindcss.com/docs/caret-color
-         */
-        new ClassGroup( "caret-color", "caret", _any ),
-        /*
-         * Pointer Events
-         * See https://tailwindcss.com/docs/pointer-events
-         */
-        new ClassGroup( "pointer-events", "pointer-events", _autoAndNone ),
-        /*
-         * Resize
-         * See https://tailwindcss.com/docs/resize
-         */
-        new ClassGroup( "resize", "resize", ["none", "y", "x", ""] ),
-        /*
-         * Scroll Behavior
-         * See https://tailwindcss.com/docs/scroll-behavior
-         */
-        new ClassGroup( "scroll-behavior", "scroll", ["auto", "smooth"] ),
-        /*
-         * Scroll Margin
-         * See https://tailwindcss.com/docs/scroll-margin
-         */
-        new ClassGroup( "scroll-m", "scroll-m", _spacings ),
-        /*
-         * Scroll Margin X
-         * See https://tailwindcss.com/docs/scroll-margin
-         */
-        new ClassGroup( "scroll-mx", "scroll-mx", _spacings ),
-        /*
-         * Scroll Margin Y
-         * See https://tailwindcss.com/docs/scroll-margin
-         */
-        new ClassGroup( "scroll-my", "scroll-my", _spacings ),
-        /*
-         * Scroll Margin Start
-         * See https://tailwindcss.com/docs/scroll-margin
-         */
-        new ClassGroup( "scroll-ms", "scroll-ms", _spacings ),
-        /*
-         * Scroll Margin End
-         * See https://tailwindcss.com/docs/scroll-margin
-         */
-        new ClassGroup( "scroll-me", "scroll-me", _spacings ),
-        /*
-         * Scroll Margin Top
-         * See https://tailwindcss.com/docs/scroll-margin
-         */
-        new ClassGroup( "scroll-mt", "scroll-mt", _spacings ),
-        /*
-         * Scroll Margin Right
-         * See https://tailwindcss.com/docs/scroll-margin
-         */
-        new ClassGroup( "scroll-mr", "scroll-mr", _spacings ),
-        /*
-         * Scroll Margin Bottom
-         * See https://tailwindcss.com/docs/scroll-margin
-         */
-        new ClassGroup( "scroll-mb", "scroll-mb", _spacings ),
-        /*
-         * Scroll Margin Left
-         * See https://tailwindcss.com/docs/scroll-margin
-         */
-        new ClassGroup( "scroll-ml", "scroll-ml", _spacings ),
-        /*
-         * Scroll Padding
-         * See https://tailwindcss.com/docs/scroll-padding
-         */
-        new ClassGroup( "scroll-p", "scroll-p", _spacings ),
-        /*
-         * Scroll Padding X
-         * See https://tailwindcss.com/docs/scroll-padding
-         */
-        new ClassGroup( "scroll-px", "scroll-px", _spacings ),
-        /*
-         * Scroll Padding Y
-         * See https://tailwindcss.com/docs/scroll-padding
-         */
-        new ClassGroup( "scroll-py", "scroll-py", _spacings ),
-        /*
-         * Scroll Padding Start
-         * See https://tailwindcss.com/docs/scroll-padding
-         */
-        new ClassGroup( "scroll-ps", "scroll-ps", _spacings ),
-        /*
-         * Scroll Padding End
-         * See https://tailwindcss.com/docs/scroll-padding
-         */
-        new ClassGroup( "scroll-pe", "scroll-pe", _spacings ),
-        /*
-         * Scroll Padding Top
-         * See https://tailwindcss.com/docs/scroll-padding
-         */
-        new ClassGroup( "scroll-pt", "scroll-pt", _spacings ),
-        /*
-         * Scroll Padding Right
-         * See https://tailwindcss.com/docs/scroll-padding
-         */
-        new ClassGroup( "scroll-pr", "scroll-pr", _spacings ),
-        /*
-         * Scroll Padding Bottom
-         * See https://tailwindcss.com/docs/scroll-padding
-         */
-        new ClassGroup( "scroll-pb", "scroll-pb", _spacings ),
-        /*
-         * Scroll Padding Left
-         * See https://tailwindcss.com/docs/scroll-padding
-         */
-        new ClassGroup( "scroll-pl", "scroll-pl", _spacings ),
-        /*
-         * Scroll Snap Align
-         * See https://tailwindcss.com/docs/scroll-snap-align
-         */
-        new ClassGroup( "snap-align", "snap", ["start", "end", "center", "align-none"] ),
-        /*
-         * Scroll Snap Stop
-         * See https://tailwindcss.com/docs/scroll-snap-stop
-         */
-        new ClassGroup( "snap-stop", "snap", ["normal", "always"] ),
-        /*
-         * Scroll Snap Type
-         * See https://tailwindcss.com/docs/scroll-snap-type
-         */
-        new ClassGroup( "snap-type", "snap", ["none", "x", "y", "both"] ),
-        /*
-         * Scroll Snap Type Strictness
-         * See https://tailwindcss.com/docs/scroll-snap-type
-         */
-        new ClassGroup( "snap-strictness", "snap", ["mandatory", "proximity"] ),
-        /*
-         * Touch Action
-         * See https://tailwindcss.com/docs/touch-action
-         */
-        new ClassGroup( "touch", "touch", ["auto", "none", "manipulation"] ),
-        /*
-         * Touch Action X
-         * See https://tailwindcss.com/docs/touch-action
-         */
-        new ClassGroup( "touch-x", "touch-pan", ["x", "left", "right"] ),
-        /*
-         * Touch Action Y
-         * See https://tailwindcss.com/docs/touch-action
-         */
-        new ClassGroup( "touch-y", "touch-pan", ["y", "up", "down"] ),
-        /*
-         * Touch Action Pinch Zoom
-         * See https://tailwindcss.com/docs/touch-action
-         */
-        new ClassGroup( "touch-pz", ["touch-pinch-zoom"] ),
-        /*
-         * User Select
-         * See https://tailwindcss.com/docs/user-select
-         */
-        new ClassGroup( "select", "select", ["none", "text", "all", "auto"] ),
-        /*
-         * Will Change
-         * See https://tailwindcss.com/docs/will-change
-         */
-        new ClassGroup( "will-change", "will-change", ["auto", "scroll", "contents", "transform"], _arbitraryValue ),
-        /*
-         * Fill
-         * See https://tailwindcss.com/docs/fill
-         */
-        new ClassGroup( "fill", "fill", _none, _any ),
-        /*
-         * Stroke Width
-         * See https://tailwindcss.com/docs/stroke-width
-         */
-        new ClassGroup( "stroke-w", "stroke", [Validators.IsLength, Validators.IsArbitraryLength, Validators.IsArbitraryNumber] ),
-        /*
-         * Stroke
-         * See https://tailwindcss.com/docs/stroke
-         */
-        new ClassGroup( "stroke", "stroke", _none, _any ),
-        /*
-         * Screen Readers
-         * See https://tailwindcss.com/docs/screen-readers
-         */
-        new ClassGroup( "sr", ["sr-only", "not-sr-only"] ),
-        /*
-         * Forced Color Adjust
-         * See https://tailwindcss.com/docs/forced-color-adjust
-         */
-        new ClassGroup( "forced-color-adjust", "forced-color-adjust", _autoAndNone ),
-    ];
-
     private static readonly Dictionary<string, string[]> _conflictingClassGroups = new( 46 )
     {
         ["overflow"] = ["overflow-x", "overflow-y"],
@@ -1661,29 +115,34 @@ public class TwMergeConfig
     };
 
     /// <summary>
-    /// Gets the maximum size of the internal LRU cache.
+    /// Gets or sets the maximum size of the LRU cache used for memoizing results.
     /// </summary>
     /// <remarks>
     /// The default is 500
     /// </remarks>
-    public int CacheSize { get; init; }
+    public int CacheSize { get; set; }
 
     /// <summary>
-    /// Gets the <seealso href="https://tailwindcss.com/docs/configuration#separator">separator</seealso> that is used to separate 
-    /// modifiers (e.g., screen sizes, hover, focus, etc.) from utility names.
+    /// Gets or sets the <seealso href="https://tailwindcss.com/docs/configuration#separator">separator</seealso> 
+    /// that is used to separate modifiers (e.g., screen sizes, hover, focus, etc.) from utility names.
     /// </summary>
     /// <remarks>
     /// The default is <c>:</c>
     /// </remarks>
-    public string Separator { get; init; }
+    public string Separator { get; set; }
 
     /// <summary>
-    /// Gets the <seealso href="https://tailwindcss.com/docs/configuration#prefix">prefix</seealso> that allows
-    /// you to add a custom prefix to all of Tailwind’s generated utility classes.
+    /// Gets or sets the <seealso href="https://tailwindcss.com/docs/configuration#prefix">prefix</seealso> 
+    /// that allows you to add a custom prefix to all of Tailwind’s generated utility classes.
     /// </summary>
-    public string? Prefix { get; init; }
+    public string? Prefix { get; set; }
 
-    internal ClassGroup[] ClassGroups { get; }
+    /// <summary>
+    /// Gets or sets the theme configuration.
+    /// </summary>
+    public Dictionary<string, object[]> Theme { get; set; }
+
+    internal ClassGroup[] ClassGroups { get; init; }
     internal IReadOnlyDictionary<string, string[]> ConflictingClassGroups { get; }
     internal IReadOnlyDictionary<string, string[]> ConflictingClassGroupModifiers { get; }
 
@@ -1694,7 +153,1584 @@ public class TwMergeConfig
     {
         CacheSize = 500;
         Separator = ":";
-        ClassGroups = _classGroups;
+
+        var colors = () => Theme?["colors"];
+        var spacing = () => Theme?["spacing"];
+        var blur = () => Theme?["blur"];
+        var brightness = () => Theme?["brightness"];
+        var borderColor = () => Theme?["borderColor"];
+        var borderRadius = () => Theme?["borderRadius"];
+        var borderSpacing = () => Theme?["borderSpacing"];
+        var borderWidth = () => Theme?["borderWidth"];
+        var contrast = () => Theme?["contrast"];
+        var grayscale = () => Theme?["grayscale"];
+        var hueRotate = () => Theme?["hueRotate"];
+        var invert = () => Theme?["invert"];
+        var gap = () => Theme?["gap"];
+        var gradientColorStops = () => Theme?["gradientColorStops"];
+        var gradientColorStopPositions = () => Theme?["gradientColorStopPositions"];
+        var inset = () => Theme?["inset"];
+        var margin = () => Theme?["margin"];
+        var opacity = () => Theme?["opacity"];
+        var padding = () => Theme?["padding"];
+        var saturate = () => Theme?["saturate"];
+        var scale = () => Theme?["scale"];
+        var sepia = () => Theme?["sepia"];
+        var skew = () => Theme?["skew"];
+        var space = () => Theme?["space"];
+        var translate = () => Theme?["translate"];
+
+        object[] any = [Validators.IsAny];
+        object[] number = [Validators.IsNumber, Validators.IsArbitraryNumber];
+        object[] numberAndArbitrary = [.. number, Validators.IsArbitraryValue];
+        object[] spacingWithArbitrary = [Validators.IsArbitraryValue, spacing];
+        object[] spacingWithAutoAndArbitrary = ["auto", Validators.IsArbitraryValue, spacing];
+        object[] lengthWithEmptyAndArbitrary = ["", Validators.IsLength, Validators.IsArbitraryLength];
+        object[] zeroAndEmpty = ["", "0", Validators.IsArbitraryValue];
+
+        string[] autoAndNone = ["auto", "none"];
+        string[] align = ["start", "end", "center", "between", "around", "evenly", "stretch"];
+        string[] breaks = ["auto", "avoid", "all", "avoid-page", "page", "left", "right", "column"];
+        string[] blendModes = [
+            "normal",
+            "multiply",
+            "screen",
+            "overlay",
+            "darken",
+            "lighten",
+            "color-dodge",
+            "color-burn",
+            "hard-light",
+            "soft-light",
+            "difference",
+            "exclusion",
+            "hue",
+            "saturation",
+            "color",
+            "luminosity"
+        ];
+        string[] lineStyles = ["solid", "dashed", "dotted", "double", "none"];
+        string[] overscroll = ["auto", "contain", "none"];
+        string[] overflow = ["auto", "hidden", "clip", "visible", "scroll"];
+        string[] positions = ["bottom", "center", "left", "left-bottom", "left-top", "right", "right-bottom", "right-top", "top"];
+
+        Theme = new()
+        {
+            ["colors"] = [Validators.IsAny],
+            ["spacing"] = [Validators.IsLength, Validators.IsArbitraryLength],
+            ["blur"] = ["none", "", Validators.IsTshirtSize, Validators.IsArbitraryValue],
+            ["brightness"] = number,
+            ["borderRadius"] = ["none", "", "full", Validators.IsTshirtSize, Validators.IsArbitraryValue],
+            ["borderSpacing"] = spacingWithArbitrary,
+            ["borderWidth"] = lengthWithEmptyAndArbitrary,
+            ["contrast"] = number,
+            ["grayscale"] = zeroAndEmpty,
+            ["hueRotate"] = numberAndArbitrary,
+            ["invert"] = zeroAndEmpty,
+            ["gap"] = spacingWithArbitrary,
+            ["gradientColorStopPositions"] = [Validators.IsPercent, Validators.IsArbitraryLength],
+            ["inset"] = spacingWithAutoAndArbitrary,
+            ["margin"] = spacingWithAutoAndArbitrary,
+            ["opacity"] = number,
+            ["padding"] = spacingWithArbitrary,
+            ["saturate"] = number,
+            ["scale"] = number,
+            ["sepia"] = zeroAndEmpty,
+            ["skew"] = numberAndArbitrary,
+            ["space"] = spacingWithArbitrary,
+            ["translate"] = spacingWithArbitrary
+        };
+
+        // No way to reference the same object during initialization
+        Theme["borderColor"] = colors();
+        Theme["gradientColorStops"] = colors();
+
+        ClassGroups = [
+            /*
+            * Aspect Ratio
+            * See https://tailwindcss.com/docs/aspect-ratio
+            */
+            new ClassGroup( "aspect", "aspect", ["auto", "square", "video", Validators.IsArbitraryValue] ),
+            /*
+             * Container
+             * See https://tailwindcss.com/docs/container
+             */
+            new ClassGroup( "container", ["container"] ),
+            /*
+             * Columns
+             * See https://tailwindcss.com/docs/columns
+             */
+            new ClassGroup( "columns", "columns", [Validators.IsTshirtSize] ),
+            /*
+             * Break After
+             * See https://tailwindcss.com/docs/break-after
+             */
+            new ClassGroup( "break-after", "break-after", breaks ),
+            /*
+             * Break Before
+             * See https://tailwindcss.com/docs/break-before
+             */
+            new ClassGroup( "break-before", "break-before", breaks ),
+            /*
+             * Break Inside
+             * See https://tailwindcss.com/docs/break-inside
+             */
+            new ClassGroup( "break-inside", "break-inside", ["auto", "avoid", "avoid-page", "avoid-column"] ),
+            /*
+             * Box Decoration Break
+             * See https://tailwindcss.com/docs/box-decoration-break
+             */
+            new ClassGroup( "box-decoration", "box-decoration", ["slice", "clone"] ),
+            /*
+             * Box Sizing
+             * See https://tailwindcss.com/docs/box-sizing
+             */
+            new ClassGroup( "box", "box", ["border", "content"] ),
+            /*
+             * Display
+             * See https://tailwindcss.com/docs/display
+             */
+            new ClassGroup( "display", [
+                "block",
+                "inline-block",
+                "inline",
+                "flex",
+                "inline-flex",
+                "table",
+                "inline-table",
+                "table-caption",
+                "table-cell",
+                "table-column",
+                "table-column-group",
+                "table-footer-group",
+                "table-header-group",
+                "table-row-group",
+                "table-row",
+                "flow-root",
+                "grid",
+                "inline-grid",
+                "contents",
+                "list-item",
+                "hidden"] ),
+            /*
+             * Floats
+             * See https://tailwindcss.com/docs/float
+             */
+            new ClassGroup( "float", "float", ["right", "left", "none", "start", "end"] ),
+            /*
+             * Clear
+             * See https://tailwindcss.com/docs/clear
+             */
+            new ClassGroup( "clear", "clear", ["left", "right", "both", "none", "start", "end"] ),
+            /*
+             * Isolation
+             * See https://tailwindcss.com/docs/isolation
+             */
+            new ClassGroup( "isolation", ["isolate", "isolation-auto"] ),
+            /*
+             * Object Fit
+             * See https://tailwindcss.com/docs/object-fit
+             */
+            new ClassGroup( "object-fit", "object", ["contain", "cover", "fill", "none", "scale-down"] ),
+            /*
+             * Object Position
+             * See https://tailwindcss.com/docs/object-position
+             */
+            new ClassGroup( "object-position", "object", [.. positions, Validators.IsArbitraryValue] ),
+            /*
+             * Overflow
+             * See https://tailwindcss.com/docs/overflow
+             */
+            new ClassGroup( "overflow", "overflow", overflow ),
+            /*
+             * Overflow X
+             * See https://tailwindcss.com/docs/overflow
+             */
+            new ClassGroup( "overflow-x", "overflow-x", overflow ),
+            /*
+             * Overflow Y
+             * See https://tailwindcss.com/docs/overflow
+             */
+            new ClassGroup( "overflow-y", "overflow-y", overflow ),
+            /*
+             * Overscroll Behavior
+             * See https://tailwindcss.com/docs/overscroll-behavior
+             */
+            new ClassGroup( "overscroll", "overscroll", overscroll ),
+            /*
+             * Overscroll Behavior X
+             * See https://tailwindcss.com/docs/overscroll-behavior
+             */
+            new ClassGroup( "overscroll-x", "overscroll-x", overscroll ),
+            /*
+             * Overscroll Behavior Y
+             * See https://tailwindcss.com/docs/overscroll-behavior
+             */
+            new ClassGroup( "overscroll-y", "overscroll-y", overscroll ),
+            /*
+             * Position
+             * See https://tailwindcss.com/docs/position
+             */
+            new ClassGroup( "position", ["static", "fixed", "absolute", "relative", "sticky"] ),
+            /*
+             * Top / Right / Bottom / Left
+             * See https://tailwindcss.com/docs/top-right-bottom-left
+             */
+            new ClassGroup( "inset", "inset", [inset] ),
+            /*
+             * Right / Left
+             * See https://tailwindcss.com/docs/top-right-bottom-left
+             */
+            new ClassGroup( "inset-x", "inset-x", [inset] ),
+            /*
+             * Top / Bottom
+             * See https://tailwindcss.com/docs/top-right-bottom-left
+             */
+            new ClassGroup( "inset-y", "inset-y", [inset] ),
+            /*
+             * Start
+             * See https://tailwindcss.com/docs/top-right-bottom-left
+             */
+            new ClassGroup( "start", "start", [inset] ),
+            /*
+             * End
+             * See https://tailwindcss.com/docs/top-right-bottom-left
+             */
+            new ClassGroup( "end", "end", [inset] ),
+            /*
+             * Top
+             * See https://tailwindcss.com/docs/top-right-bottom-left
+             */
+            new ClassGroup( "top", "top", [inset] ),
+            /*
+             * Right
+             * See https://tailwindcss.com/docs/top-right-bottom-left
+             */
+            new ClassGroup( "right", "right", [inset] ),
+            /*
+             * Bottom
+             * See https://tailwindcss.com/docs/top-right-bottom-left
+             */
+            new ClassGroup( "bottom", "bottom", [inset] ),
+            /*
+             * Left
+             * See https://tailwindcss.com/docs/top-right-bottom-left
+             */
+            new ClassGroup( "left", "left", [inset] ),
+            /*
+             * Visibility
+             * See https://tailwindcss.com/docs/visibility
+             */
+            new ClassGroup( "visibility", ["visible", "invisible", "collapse"] ),
+            /*
+             * Z-Index
+             * See https://tailwindcss.com/docs/z-index
+             */
+            new ClassGroup( "z", "z", ["auto", Validators.IsInteger, Validators.IsArbitraryValue] ),
+            /*
+             * Flex Basis
+             * See https://tailwindcss.com/docs/flex-basis
+             */
+            new ClassGroup( "basis", "basis", spacingWithAutoAndArbitrary ),
+            /*
+             * Flex Direction
+             * See https://tailwindcss.com/docs/flex-direction
+             */
+            new ClassGroup( "flex-direction", "flex", ["row", "row-reverse", "col", "col-reverse"] ),
+            /*
+             * Flex Wrap
+             * See https://tailwindcss.com/docs/flex-wrap
+             */
+            new ClassGroup( "flex-wrap", "flex", ["wrap", "wrap-reverse", "nowrap"] ),
+            /*
+             * Flex
+             * See https://tailwindcss.com/docs/flex
+             */
+            new ClassGroup( "flex", "flex", ["1", "auto", "initial", "none", Validators.IsArbitraryValue] ),
+            /*
+             * Flex Grow
+             * See https://tailwindcss.com/docs/flex-grow
+             */
+            new ClassGroup( "grow", "grow", zeroAndEmpty ),
+            /*
+             * Flex Shrink
+             * See https://tailwindcss.com/docs/flex-shrink
+             */
+            new ClassGroup( "shrink", "shrink", zeroAndEmpty ),
+            /*
+             * Order
+             * See https://tailwindcss.com/docs/order
+             */
+            new ClassGroup( "order", "order", ["first", "last", "none", Validators.IsInteger, Validators.IsArbitraryValue] ),
+            /*
+             * Grid Template Columns
+             * See https://tailwindcss.com/docs/grid-template-columns
+             */
+            new ClassGroup( "grid-cols", "grid-cols", any ),
+            /*
+             * Grid Column Start / End
+             * See https://tailwindcss.com/docs/grid-column
+             */
+            new ClassGroup( "col-start-end", "col", ["auto", Validators.IsArbitraryValue] ),
+            /*
+             * Grid Column Span
+             * See https://tailwindcss.com/docs/grid-column
+             */
+            new ClassGroup( "col-start-end", "col-span", ["full", .. numberAndArbitrary] ),
+            /*
+             * Grid Column Start
+             * See https://tailwindcss.com/docs/grid-column
+             */
+            new ClassGroup( "col-start", "col-start", ["auto", .. numberAndArbitrary] ),
+            /*
+             * Grid Column End
+             * See https://tailwindcss.com/docs/grid-column
+             */
+            new ClassGroup( "col-end", "col-end", ["auto", .. numberAndArbitrary] ),
+            /*
+             * Grid Template Rows
+             * See https://tailwindcss.com/docs/grid-template-rows
+             */
+            new ClassGroup( "grid-rows", "grid-rows", any ),
+            /*
+             * Grid Row Start / End
+             * See https://tailwindcss.com/docs/grid-row
+             */
+            new ClassGroup( "row-start-end", "row", ["auto", Validators.IsArbitraryValue] ),
+            /*
+             * Grid Row Span
+             * See https://tailwindcss.com/docs/grid-row
+             */
+            new ClassGroup( "row-start-end", "row-span", numberAndArbitrary ),
+            /*
+             * Grid Row Start
+             * See https://tailwindcss.com/docs/grid-row
+             */
+            new ClassGroup( "row-start", "row-start", ["auto", .. numberAndArbitrary] ),
+            /*
+             * Grid Row End
+             * See https://tailwindcss.com/docs/grid-row
+             */
+            new ClassGroup( "row-end", "row-end", ["auto", .. numberAndArbitrary] ),
+            /*
+             * Grid Auto Flow
+             * See https://tailwindcss.com/docs/grid-auto-flow
+             */
+            new ClassGroup( "grid-flow", "grid-flow", ["row", "col", "dense", "row-dense", "col-dense"] ),
+            /*
+             * Grid Auto Columns
+             * See https://tailwindcss.com/docs/grid-auto-columns
+             */
+            new ClassGroup( "auto-cols", "auto-cols", ["auto", "min", "max", "fr", Validators.IsArbitraryValue] ),
+            /*
+             * Grid Auto Rows
+             * See https://tailwindcss.com/docs/grid-auto-rows
+             */
+            new ClassGroup( "auto-rows", "auto-rows", ["auto", "min", "max", "fr", Validators.IsArbitraryValue] ),
+            /*
+             * Gap
+             * See https://tailwindcss.com/docs/gap
+             */
+            new ClassGroup( "gap", "gap", [gap] ),
+            /*
+             * Gap X
+             * See https://tailwindcss.com/docs/gap
+             */
+            new ClassGroup( "gap-x", "gap-x", [gap] ),
+            /*
+             * Gap Y
+             * See https://tailwindcss.com/docs/gap
+             */
+            new ClassGroup( "gap-y", "gap-y", [gap] ),
+            /*
+             * Justify Content
+             * See https://tailwindcss.com/docs/justify-content
+             */
+            new ClassGroup( "justify-content", "justify", ["normal", .. align] ),
+            /*
+             * Justify Items
+             * See https://tailwindcss.com/docs/justify-items
+             */
+            new ClassGroup( "justify-items", "justify-items", ["start", "end", "center", "stretch"] ),
+            /*
+             * Justify Self
+             * See https://tailwindcss.com/docs/justify-self
+             */
+            new ClassGroup( "justify-self", "justify-self", ["auto", "start", "end", "center", "stretch"] ),
+            /*
+             * Align Content
+             * See https://tailwindcss.com/docs/align-content
+             */
+            new ClassGroup( "align-content", "content", ["normal", "baseline", .. align] ),
+            /*
+             * Align Items
+             * See https://tailwindcss.com/docs/align-items
+             */
+            new ClassGroup( "align-items", "items", ["start", "end", "center", "baseline", "stretch"] ),
+            /*
+             * Align Self
+             * See https://tailwindcss.com/docs/align-self
+             */
+            new ClassGroup( "align-self", "self", ["auto", "start", "end", "center", "baseline", "stretch"] ),
+            /*
+             * Place Content
+             * See https://tailwindcss.com/docs/place-content
+             */
+            new ClassGroup( "place-content", "place-content", ["baseline", .. align] ),
+            /*
+             * Place Items
+             * See https://tailwindcss.com/docs/place-items
+             */
+            new ClassGroup( "place-items", "place-items", ["start", "end", "center", "baseline", "stretch"] ),
+            /*
+             * Place Self
+             * See https://tailwindcss.com/docs/place-self
+             */
+            new ClassGroup( "place-self", "place-self", ["auto", "start", "end", "center", "stretch"] ),
+            /*
+             * Padding
+             * See https://tailwindcss.com/docs/padding
+             */
+            new ClassGroup( "p", "p", [padding] ),
+            /*
+             * Padding X
+             * See https://tailwindcss.com/docs/padding
+             */
+            new ClassGroup( "px", "px", [padding] ),
+            /*
+             * Padding Y
+             * See https://tailwindcss.com/docs/padding
+             */
+            new ClassGroup( "py", "py", [padding] ),
+            /*
+             * Padding Start
+             * See https://tailwindcss.com/docs/padding
+             */
+            new ClassGroup( "ps", "ps", [padding] ),
+            /*
+             * Padding End
+             * See https://tailwindcss.com/docs/padding
+             */
+            new ClassGroup( "pe", "pe", [padding] ),
+            /*
+             * Padding Top
+             * See https://tailwindcss.com/docs/padding
+             */
+            new ClassGroup( "pt", "pt", [padding] ),
+            /*
+             * Padding Right
+             * See https://tailwindcss.com/docs/padding
+             */
+            new ClassGroup( "pr", "pr", [padding] ),
+            /*
+             * Padding Bottom
+             * See https://tailwindcss.com/docs/padding
+             */
+            new ClassGroup( "pb", "pb", [padding] ),
+            /*
+             * Padding Left
+             * See https://tailwindcss.com/docs/padding
+             */
+            new ClassGroup( "pl", "pl", [padding] ),
+            /*
+             * Margin
+             * See https://tailwindcss.com/docs/margin
+             */
+            new ClassGroup( "m", "m", [margin] ),
+            /*
+             * Margin X
+             * See https://tailwindcss.com/docs/margin
+             */
+            new ClassGroup( "mx", "mx", [margin] ),
+            /*
+             * Margin Y
+             * See https://tailwindcss.com/docs/margin
+             */
+            new ClassGroup( "my", "my", [margin] ),
+            /*
+             * Margin Start
+             * See https://tailwindcss.com/docs/margin
+             */
+            new ClassGroup( "ms", "ms", [margin] ),
+            /*
+             * Margin End
+             * See https://tailwindcss.com/docs/margin
+             */
+            new ClassGroup( "me", "me", [margin] ),
+            /*
+             * Margin Top
+             * See https://tailwindcss.com/docs/margin
+             */
+            new ClassGroup( "mt", "mt", [margin] ),
+            /*
+             * Margin Right
+             * See https://tailwindcss.com/docs/margin
+             */
+            new ClassGroup( "mr", "mr", [margin] ),
+            /*
+             * Margin Bottom
+             * See https://tailwindcss.com/docs/margin
+             */
+            new ClassGroup( "mb", "mb", [margin] ),
+            /*
+             * Margin Left
+             * See https://tailwindcss.com/docs/margin
+             */
+            new ClassGroup( "ml", "ml", [margin] ),
+            /*
+             * Space Between X
+             * See https://tailwindcss.com/docs/space
+             */
+            new ClassGroup( "space-x", "space-x", [space] ),
+            /*
+             * Space Between X Reverse
+             * See https://tailwindcss.com/docs/space
+             */
+            new ClassGroup( "space-x-reverse", ["space-x-reverse"] ),
+            /*
+             * Space Between Y
+             * See https://tailwindcss.com/docs/space
+             */
+            new ClassGroup( "space-y", "space-y", [space] ),
+            /*
+             * Space Between Y Reverse
+             * See https://tailwindcss.com/docs/space
+             */
+            new ClassGroup( "space-y-reverse", ["space-y-reverse"] ),
+            /*
+             * Width
+             * See https://tailwindcss.com/docs/width
+             */
+            new ClassGroup( "w", "w", ["auto", "min", "max", "fit", "svw", "lvw", "dvw", spacing, Validators.IsArbitraryValue] ),
+            /*
+             * Min-Width
+             * See https://tailwindcss.com/docs/min-width
+             */
+            new ClassGroup( "min-w", "min-w", ["min", "max", "fit", spacing, Validators.IsArbitraryValue] ),
+            /*
+             * Max-Width
+             * See https://tailwindcss.com/docs/max-width
+             */
+            new ClassGroup( "max-w", "max-w", ["none", "full", "min", "max", "fit", "prose", spacing, Validators.IsTshirtSize] ),
+            /*
+             * Max-Width Screen
+             * See https://tailwindcss.com/docs/max-width
+             */
+            new ClassGroup( "max-w", "max-w-screen", [Validators.IsTshirtSize] ),
+            /*
+             * Height
+             * See https://tailwindcss.com/docs/height
+             */
+            new ClassGroup( "h", "h", ["auto", "min", "max", "fit", "svh", "lvh", "dvh", spacing, Validators.IsArbitraryValue] ),
+            /*
+             * Min-Height
+             * See https://tailwindcss.com/docs/min-height
+             */
+            new ClassGroup( "min-h", "min-h", ["min", "max", "fit", "svh", "lvh", "dvh", spacing, Validators.IsArbitraryValue] ),
+            /*
+             * Max-Height
+             * See https://tailwindcss.com/docs/max-height
+             */
+            new ClassGroup( "max-h", "max-h", ["min", "max", "fit", "svh", "lvh", "dvh", spacing, Validators.IsArbitraryValue] ),
+            /*
+             * Size
+             * See https://tailwindcss.com/docs/size
+             */
+            new ClassGroup( "size", "size", ["auto", "min", "max", "fit", spacing, Validators.IsArbitraryValue] ),
+            /*
+             * Font Size
+             * See https://tailwindcss.com/docs/font-size
+             */
+            new ClassGroup( "font-size", "text", ["base", Validators.IsTshirtSize, Validators.IsArbitraryLength] ),
+            /*
+             * Font Smoothing
+             * See https://tailwindcss.com/docs/font-smoothing
+             */
+            new ClassGroup( "font-smoothing", ["antialiased", "subpixel-antialiased"] ),
+            /*
+             * Font Style
+             * See https://tailwindcss.com/docs/font-style
+             */
+            new ClassGroup( "font-style", ["italic", "not-italic"] ),
+            /*
+             * Font Weight
+             * See https://tailwindcss.com/docs/font-weight
+             */
+            new ClassGroup( "font-weight", "font", [
+                "thin",
+                "extralight",
+                "light",
+                "normal",
+                "medium",
+                "semibold",
+                "bold",
+                "extrabold",
+                "bold",
+                Validators.IsArbitraryNumber] ),
+            /*
+             * Font Family
+             * See https://tailwindcss.com/docs/font-family
+             */
+            new ClassGroup( "font-family", "font", any ),
+            /*
+             * Font Variant Numeric
+             * See https://tailwindcss.com/docs/font-variant-numeric
+             */
+            new ClassGroup( "fvn-normal", ["normal-nums"] ),
+            /*
+             * Font Variant Numeric
+             * See https://tailwindcss.com/docs/font-variant-numeric
+             */
+            new ClassGroup( "fvn-ordinal", ["ordinal"] ),
+            /*
+             * Font Variant Numeric
+             * See https://tailwindcss.com/docs/font-variant-numeric
+             */
+            new ClassGroup( "fvn-slashed-zero", ["slashed-zero"] ),
+            /*
+             * Font Variant Numeric
+             * See https://tailwindcss.com/docs/font-variant-numeric
+             */
+            new ClassGroup( "fvn-figure", ["lining-nums", "oldstyle-nums"] ),
+            /*
+             * Font Variant Numeric
+             * See https://tailwindcss.com/docs/font-variant-numeric
+             */
+            new ClassGroup( "fvn-spacing", ["proportional-nums", "tabular-nums"] ),
+            /*
+             * Font Variant Numeric
+             * See https://tailwindcss.com/docs/font-variant-numeric
+             */
+            new ClassGroup( "fvn-fraction", ["diagonal-fractions", "stacked-fractions"] ),
+            /*
+             * Letter Spacing
+             * See https://tailwindcss.com/docs/letter-spacing
+             */
+            new ClassGroup( "tracking", "tracking", [
+                "tighter",
+                "tight",
+                "normal",
+                "wide",
+                "wider",
+                "widest",
+                Validators.IsArbitraryValue] ),
+            /*
+             * Line Clamp
+             * See https://tailwindcss.com/docs/line-clamp
+             */
+            new ClassGroup( "line-clamp", "line-clamp", ["none", .. number] ),
+            /*
+             * Line Height
+             * See https://tailwindcss.com/docs/line-height
+             */
+            new ClassGroup( "leading", "leading", [
+                "none",
+                "tight",
+                "snug",
+                "normal",
+                "relaxed",
+                "loose",
+                Validators.IsLength,
+                Validators.IsArbitraryValue] ),
+            /*
+             * List Style Image
+             * See https://tailwindcss.com/docs/list-style-image
+             */
+            new ClassGroup( "list-image", "list-image", ["none", Validators.IsArbitraryValue] ),
+            /*
+             * List Style Type
+             * See https://tailwindcss.com/docs/list-style-type
+             */
+            new ClassGroup( "list-style-type", "list", ["none", "disc", "decimal", Validators.IsArbitraryValue] ),
+            /*
+             * List Style Position
+             * See https://tailwindcss.com/docs/list-style-position
+             */
+            new ClassGroup( "list-style-position", "list", ["inside", "outside"] ),
+            /*
+             * Placeholder Color
+             * See https://tailwindcss.com/docs/placeholder-color
+             */
+            new ClassGroup( "placeholder-color", "placeholder", [colors] ),
+            /*
+             * Text Alignment
+             * See https://tailwindcss.com/docs/text-align
+             */
+            new ClassGroup( "text-alignment", "text", ["left", "center", "right", "justify", "start", "end"] ),
+            /*
+             * Text Color
+             * See https://tailwindcss.com/docs/text-color
+             */
+            new ClassGroup( "text-color", "text", [colors] ),
+            /*
+             * Text Decoration
+             * See https://tailwindcss.com/docs/text-decoration
+             */
+            new ClassGroup( "text-decoration", ["underline", "overline", "line-through", "no-underline"] ),
+            /*
+             * Text Decoration Style
+             * See https://tailwindcss.com/docs/text-decoration-style
+             */
+            new ClassGroup( "text-decoration-style", "decoration", ["wavy", .. lineStyles] ),
+            /*
+             * Text Decoration Color
+             * See https://tailwindcss.com/docs/text-decoration-color
+             */
+            new ClassGroup( "text-decoration-color", "decoration", [colors] ),
+            /*
+             * Text Decoration Thickness
+             * See https://tailwindcss.com/docs/text-decoration-thickness
+             */
+            new ClassGroup( "text-decoration-thickness", "decoration", ["auto", "from-font", Validators.IsLength, Validators.IsArbitraryLength] ),
+            /*
+             * Text Underline Offset
+             * See https://tailwindcss.com/docs/text-underline-offset
+             */
+            new ClassGroup( "underline-offset", "underline-offset", ["auto", Validators.IsLength, Validators.IsArbitraryValue] ),
+            /*
+             * Text Transform
+             * See https://tailwindcss.com/docs/text-transform
+             */
+            new ClassGroup( "text-transform", ["uppercase", "lowercase", "capitalize", "normal-case"] ),
+            /*
+             * Text Overflow
+             * See https://tailwindcss.com/docs/text-overflow
+             */
+            new ClassGroup( "text-overflow", ["truncate", "text-ellipsis", "text-clip"] ),
+            /*
+             * Text Wrap
+             * See https://tailwindcss.com/docs/text-wrap
+             */
+            new ClassGroup( "text-wrap", "text", ["wrap", "nowrap", "balance", "pretty"] ),
+            /*
+             * Text Indent
+             * See https://tailwindcss.com/docs/text-indent
+             */
+            new ClassGroup( "indent", "indent", spacingWithArbitrary ),
+            /*
+             * Vertical Alignment
+             * See https://tailwindcss.com/docs/vertical-align
+             */
+            new ClassGroup( "vertical-align", "align", [
+                "baseline",
+                "top",
+                "middle",
+                "bottom",
+                "text-top",
+                "text-bottom",
+                "sub",
+                "super",
+                Validators.IsArbitraryValue] ),
+            /*
+             * Whitespace
+             * See https://tailwindcss.com/docs/whitespace
+             */
+            new ClassGroup( "whitespace", "whitespace", [
+                "normal",
+                "nowrap",
+                "pre",
+                "pre-line",
+                "pre-wrap",
+                "break-spaces"] ),
+            /*
+             * Work Break
+             * See https://tailwindcss.com/docs/word-break
+             */
+            new ClassGroup( "break", "break", ["normal", "words", "all", "keep"] ),
+            /*
+             * Hyphens
+             * See https://tailwindcss.com/docs/hyphens
+             */
+            new ClassGroup( "hyphens", "hyphens", ["none", "manual", "auto"] ),
+            /*
+             * Content
+             * See https://tailwindcss.com/docs/content
+             */
+            new ClassGroup( "content", "content", ["none", Validators.IsArbitraryValue] ),
+            /*
+             * Background Attachment
+             * See https://tailwindcss.com/docs/background-attachment
+             */
+            new ClassGroup( "bg-attachment", "bg", ["fixed", "local", "scroll"] ),
+            /*
+             * Background Clip
+             * See https://tailwindcss.com/docs/background-clip
+             */
+            new ClassGroup( "bg-clip", "bg-clip", ["border", "padding", "content", "text"] ),
+            /*
+             * Background Origin
+             * See https://tailwindcss.com/docs/background-origin
+             */
+            new ClassGroup( "bg-origin", "bg-origin", ["border", "padding", "content"] ),
+            /*
+             * Background Position
+             * See https://tailwindcss.com/docs/background-position
+             */
+            new ClassGroup( "bg-position", "bg", [.. positions, Validators.IsArbitraryPosition] ),
+            /*
+             * Background Repeat
+             * See https://tailwindcss.com/docs/background-repeat
+             */
+            new ClassGroup( "bg-repeat", "bg", ["no-repeat"] ),
+            /*
+             * Background Repeat
+             * See https://tailwindcss.com/docs/background-repeat
+             */
+            new ClassGroup( "bg-repeat", "bg-repeat", ["", "x", "y", "round", "space"] ),
+            /*
+             * Background Size
+             * See https://tailwindcss.com/docs/background-size
+             */
+            new ClassGroup( "bg-size", "bg", ["auto", "cover", "contain", Validators.IsArbitrarySize] ),
+            /*
+             * Background Image
+             * See https://tailwindcss.com/docs/background-image
+             */
+            new ClassGroup( "bg-image", "bg", ["none", Validators.IsArbitraryImage] ),
+            /*
+             * Background Image Gradient To
+             * See https://tailwindcss.com/docs/background-image
+             */
+            new ClassGroup( "bg-image", "bg-gradient-to", ["t", "tr", "r", "br", "b", "bl", "l", "tl"] ),
+            /*
+             * Background Color
+             * See https://tailwindcss.com/docs/background-color
+             */
+            new ClassGroup( "bg-color", "bg", [colors] ),
+            /*
+             * Gradient Color Stops From Position
+             * See https://tailwindcss.com/docs/gradient-color-stops
+             */
+            new ClassGroup( "gradient-from-pos", "from", [gradientColorStopPositions] ),
+            /*
+             * Gradient Color Stops Via Position
+             * See https://tailwindcss.com/docs/gradient-color-stops
+             */
+            new ClassGroup( "gradient-via-pos", "via", [gradientColorStopPositions] ),
+            /*
+             * Gradient Color Stops To Position
+             * See https://tailwindcss.com/docs/gradient-color-stops
+             */
+            new ClassGroup( "gradient-to-pos", "to", [gradientColorStopPositions] ),
+            /*
+             * Gradient Color Stops From
+             * See https://tailwindcss.com/docs/gradient-color-stops
+             */
+            new ClassGroup( "gradient-from", "from", [gradientColorStops] ),
+            /*
+             * Gradient Color Stops Via
+             * See https://tailwindcss.com/docs/gradient-color-stops
+             */
+            new ClassGroup( "gradient-via", "via", [gradientColorStops] ),
+            /*
+             * Gradient Color Stops To
+             * See https://tailwindcss.com/docs/gradient-color-stops
+             */
+            new ClassGroup( "gradient-to", "to", [gradientColorStops] ),
+            /*
+             * Border Radius
+             * See https://tailwindcss.com/docs/border-radius
+             */
+            new ClassGroup( "rounded", "rounded", [borderRadius] ),
+            /*
+             * Border Radius Start
+             * See https://tailwindcss.com/docs/border-radius
+             */
+            new ClassGroup( "rounded-s", "rounded-s", [borderRadius] ),
+            /*
+             * Border Radius End
+             * See https://tailwindcss.com/docs/border-radius
+             */
+            new ClassGroup( "rounded-e", "rounded-e", [borderRadius] ),
+            /*
+             * Border Radius Top
+             * See https://tailwindcss.com/docs/border-radius
+             */
+            new ClassGroup( "rounded-t", "rounded-t", [borderRadius] ),
+            /*
+             * Border Radius Right
+             * See https://tailwindcss.com/docs/border-radius
+             */
+            new ClassGroup( "rounded-r", "rounded-r", [borderRadius] ),
+            /*
+             * Border Radius Bottom
+             * See https://tailwindcss.com/docs/border-radius
+             */
+            new ClassGroup( "rounded-b", "rounded-b", [borderRadius] ),
+            /*
+             * Border Radius Left
+             * See https://tailwindcss.com/docs/border-radius
+             */
+            new ClassGroup( "rounded-l", "rounded-l", [borderRadius] ),
+            /*
+             * Border Radius Start Start
+             * See https://tailwindcss.com/docs/border-radius
+             */
+            new ClassGroup( "rounded-ss", "rounded-ss", [borderRadius] ),
+            /*
+             * Border Radius Start End
+             * See https://tailwindcss.com/docs/border-radius
+             */
+            new ClassGroup( "rounded-se", "rounded-se", [borderRadius] ),
+            /*
+             * Border Radius End End
+             * See https://tailwindcss.com/docs/border-radius
+             */
+            new ClassGroup( "rounded-ee", "rounded-ee", [borderRadius] ),
+            /*
+             * Border Radius End Start
+             * See https://tailwindcss.com/docs/border-radius
+             */
+            new ClassGroup( "rounded-es", "rounded-es", [borderRadius] ),
+            /*
+             * Border Radius Top Left
+             * See https://tailwindcss.com/docs/border-radius
+             */
+            new ClassGroup( "rounded-tl", "rounded-tl", [borderRadius] ),
+            /*
+             * Border Radius Top Right
+             * See https://tailwindcss.com/docs/border-radius
+             */
+            new ClassGroup( "rounded-tr", "rounded-tr", [borderRadius] ),
+            /*
+             * Border Radius Bottom Right
+             * See https://tailwindcss.com/docs/border-radius
+             */
+            new ClassGroup( "rounded-br", "rounded-br", [borderRadius] ),
+            /*
+             * Border Radius Bottom Left
+             * See https://tailwindcss.com/docs/border-radius
+             */
+            new ClassGroup( "rounded-bl", "rounded-bl", [borderRadius] ),
+            /*
+             * Border Width
+             * See https://tailwindcss.com/docs/border-width
+             */
+            new ClassGroup( "border-w", "border", [borderWidth] ),
+            /*
+             * Border Width X
+             * See https://tailwindcss.com/docs/border-width
+             */
+            new ClassGroup( "border-w-x", "border-x", [borderWidth] ),
+            /*
+             * Border Width Y
+             * See https://tailwindcss.com/docs/border-width
+             */
+            new ClassGroup( "border-w-y", "border-y", [borderWidth] ),
+            /*
+             * Border Width Start
+             * See https://tailwindcss.com/docs/border-width
+             */
+            new ClassGroup( "border-w-s", "border-s", [borderWidth] ),
+            /*
+             * Border Width End
+             * See https://tailwindcss.com/docs/border-width
+             */
+            new ClassGroup( "border-w-e", "border-e", [borderWidth] ),
+            /*
+             * Border Width Top
+             * See https://tailwindcss.com/docs/border-width
+             */
+            new ClassGroup( "border-w-t", "border-t", [borderWidth] ),
+            /*
+             * Border Width Right
+             * See https://tailwindcss.com/docs/border-width
+             */
+            new ClassGroup( "border-w-r", "border-r", [borderWidth] ),
+            /*
+             * Border Width Bottom
+             * See https://tailwindcss.com/docs/border-width
+             */
+            new ClassGroup( "border-w-b", "border-b", [borderWidth] ),
+            /*
+             * Border Width Left
+             * See https://tailwindcss.com/docs/border-width
+             */
+            new ClassGroup( "border-w-l", "border-l", [borderWidth] ),
+            /*
+             * Border Style
+             * See https://tailwindcss.com/docs/border-style
+             */
+            new ClassGroup( "border-style", "border", ["hidden", .. lineStyles] ),
+            /*
+             * Divide Width X
+             * See https://tailwindcss.com/docs/divide-width
+             */
+            new ClassGroup( "divide-x", "divide-x", [borderWidth] ),
+            /*
+             * Divide Width X Reverse
+             * See https://tailwindcss.com/docs/divide-width
+             */
+            new ClassGroup( "divide-x-reverse", ["divide-x-reverse"] ),
+            /*
+             * Divide Width Y
+             * See https://tailwindcss.com/docs/divide-width
+             */
+            new ClassGroup( "divide-y", "divide-y", [borderWidth] ),
+            /*
+             * Divide Width Y Reverse
+             * See https://tailwindcss.com/docs/divide-width
+             */
+            new ClassGroup( "divide-y-reverse", ["divide-y-reverse"] ),
+            /*
+             * Divide Style
+             * See https://tailwindcss.com/docs/divide-style
+             */
+            new ClassGroup( "divide-style", "divide", lineStyles ),
+            /*
+             * Border Color
+             * See https://tailwindcss.com/docs/border-color
+             */
+            new ClassGroup( "border-color", "border", [borderColor] ),
+            /*
+             * Border Color X
+             * See https://tailwindcss.com/docs/border-color
+             */
+            new ClassGroup( "border-color-x", "border-x", [borderColor] ),
+            /*
+             * Border Color Y
+             * See https://tailwindcss.com/docs/border-color
+             */
+            new ClassGroup( "border-color-y", "border-y", [borderColor] ),
+            /*
+             * Border Color Top
+             * See https://tailwindcss.com/docs/border-color
+             */
+            new ClassGroup( "border-color-t", "border-t", [borderColor] ),
+            /*
+             * Border Color Right
+             * See https://tailwindcss.com/docs/border-color
+             */
+            new ClassGroup( "border-color-r", "border-r", [borderColor] ),
+            /*
+             * Border Color Bottom
+             * See https://tailwindcss.com/docs/border-color
+             */
+            new ClassGroup( "border-color-b", "border-b", [borderColor] ),
+            /*
+             * Border Color Left
+             * See https://tailwindcss.com/docs/border-color
+             */
+            new ClassGroup( "border-color-l", "border-l", [borderColor] ),
+            /*
+             * Divide Color
+             * See https://tailwindcss.com/docs/divide-color
+             */
+            new ClassGroup( "divide-color", "divide", [borderColor] ),
+            /*
+             * Outline Style
+             * See https://tailwindcss.com/docs/outline-style
+             */
+            new ClassGroup( "outline-style", "outline", ["", .. lineStyles] ),
+            /*
+             * Outline Offset
+             * See https://tailwindcss.com/docs/outline-offset
+             */
+            new ClassGroup( "outline-offset", "outline-offset", [Validators.IsLength, Validators.IsArbitraryLength] ),
+            /*
+             * Outline Width
+             * See https://tailwindcss.com/docs/outline-width
+             */
+            new ClassGroup( "outline-w", "outline", [Validators.IsLength, Validators.IsArbitraryLength] ),
+            /*
+             * Outline Color
+             * See https://tailwindcss.com/docs/outline-color
+             */
+            new ClassGroup( "outline-color", "outline", [colors] ),
+            /*
+             * Ring Width
+             * See https://tailwindcss.com/docs/ring-width
+             */
+            new ClassGroup( "ring-w", "ring", lengthWithEmptyAndArbitrary ),
+            /*
+             * Ring Width Inset
+             * See https://tailwindcss.com/docs/ring-width
+             */
+            new ClassGroup( "ring-w-inset", ["ring-inset"] ),
+            /*
+             * Ring Color
+             * See https://tailwindcss.com/docs/ring-color
+             */
+            new ClassGroup( "ring-color", "ring", [colors] ),
+            /*
+             * Ring Offset Width
+             * See https://tailwindcss.com/docs/ring-offset-width
+             */
+            new ClassGroup( "ring-offset-w", "ring-offset", [Validators.IsLength, Validators.IsArbitraryLength] ),
+            /*
+             * Ring Offset Color
+             * See https://tailwindcss.com/docs/ring-offset-color
+             */
+            new ClassGroup( "ring-offset-color", "ring-offset", [colors] ),
+            /*
+             * Shadow
+             * See https://tailwindcss.com/docs/shadow
+             */
+            new ClassGroup( "shadow", "shadow", ["", "inner", "none", Validators.IsTshirtSize, Validators.IsArbitraryShadow] ),
+            /*
+             * Shadow Color
+             * See https://tailwindcss.com/docs/shadow-color
+             */
+            new ClassGroup( "shadow-color", "shadow", any ),
+            /*
+             * Opacity
+             * See https://tailwindcss.com/docs/opacity
+             */
+            new ClassGroup( "opacity", "opacity", [opacity] ),
+            /*
+             * Mix Blend Mode
+             * See https://tailwindcss.com/docs/mix-blend-mode
+             */
+            new ClassGroup( "mix-blend", "mix-blend", ["plus-lighter", "plus-darker", .. blendModes] ),
+            /*
+             * Background Blend Mode
+             * See https://tailwindcss.com/docs/mix-blend-mode
+             */
+            new ClassGroup( "bg-blend", "bg-blend", blendModes ),
+            /*
+             * Blur
+             * See https://tailwindcss.com/docs/blur
+             */
+            new ClassGroup( "blur", "blur", [blur] ),
+            /*
+             * Brightness
+             * See https://tailwindcss.com/docs/brightness
+             */
+            new ClassGroup( "brightness", "brightness", [brightness] ),
+            /*
+             * Contrast
+             * See https://tailwindcss.com/docs/contrast
+             */
+            new ClassGroup( "contrast", "contrast", [contrast] ),
+            /*
+             * Drop Shadow
+             * See https://tailwindcss.com/docs/drop-shadow
+             */
+            new ClassGroup( "drop-shadow", "drop-shadow", ["none", "", Validators.IsTshirtSize, Validators.IsArbitraryValue] ),
+            /*
+             * Grayscale
+             * See https://tailwindcss.com/docs/grayscale
+             */
+            new ClassGroup( "grayscale", "grayscale", [grayscale] ),
+            /*
+             * Hue Rotate
+             * See https://tailwindcss.com/docs/hue-rotate
+             */
+            new ClassGroup( "hue-rotate", "hue-rotate", [hueRotate] ),
+            /*
+             * Invert
+             * See https://tailwindcss.com/docs/invert
+             */
+            new ClassGroup( "invert", "invert", [invert] ),
+            /*
+             * Saturate
+             * See https://tailwindcss.com/docs/saturate
+             */
+            new ClassGroup( "saturate", "saturate", [saturate] ),
+            /*
+             * Sepia
+             * See https://tailwindcss.com/docs/sepia
+             */
+            new ClassGroup( "sepia", "sepia", [sepia] ),
+            /*
+             * Backdrop Blur
+             * See https://tailwindcss.com/docs/backdrop-blur
+             */
+            new ClassGroup( "backdrop-blur", "backdrop-blur", [blur] ),
+            /*
+             * Backdrop Brightness
+             * See https://tailwindcss.com/docs/backdrop-brightness
+             */
+            new ClassGroup( "backdrop-brightness", "backdrop-brightness", [brightness] ),
+            /*
+             * Backdrop Contrast
+             * See https://tailwindcss.com/docs/backdrop-contrast
+             */
+            new ClassGroup( "backdrop-contrast", "backdrop-contrast", [contrast] ),
+            /*
+             * Backdrop Grayscale
+             * See https://tailwindcss.com/docs/backdrop-grayscale
+             */
+            new ClassGroup( "backdrop-grayscale", "backdrop-grayscale", [grayscale] ),
+            /*
+             * Backdrop Hue Rotate
+             * See https://tailwindcss.com/docs/backdrop-hue-rotate
+             */
+            new ClassGroup( "backdrop-hue-rotate", "backdrop-hue-rotate", [hueRotate] ),
+            /*
+             * Backdrop Invert
+             * See https://tailwindcss.com/docs/backdrop-invert
+             */
+            new ClassGroup( "backdrop-invert", "backdrop-invert", [invert] ),
+            /*
+             * Backdrop Opacity
+             * See https://tailwindcss.com/docs/backdrop-opacity
+             */
+            new ClassGroup( "backdrop-opacity", "backdrop-opacity", [opacity] ),
+            /*
+             * Backdrop Saturate
+             * See https://tailwindcss.com/docs/backdrop-saturate
+             */
+            new ClassGroup( "backdrop-saturate", "backdrop-saturate", [saturate] ),
+            /*
+             * Backdrop Sepia
+             * See https://tailwindcss.com/docs/backdrop-sepia
+             */
+            new ClassGroup( "backdrop-sepia", "backdrop-sepia", [sepia] ),
+            /*
+             * Border Collapse
+             * See https://tailwindcss.com/docs/border-collapse
+             */
+            new ClassGroup( "border-collapse", "border", ["collapse", "separate"] ),
+            /*
+             * Border Spacing
+             * See https://tailwindcss.com/docs/border-spacing
+             */
+            new ClassGroup( "border-spacing", "border-spacing", [borderSpacing] ),
+            /*
+             * Border Spacing X
+             * See https://tailwindcss.com/docs/border-spacing
+             */
+            new ClassGroup( "border-spacing-x", "border-spacing-x", [borderSpacing] ),
+            /*
+             * Border Spacing Y
+             * See https://tailwindcss.com/docs/border-spacing
+             */
+            new ClassGroup( "border-spacing-y", "border-spacing-y", [borderSpacing] ),
+            /*
+             * Table Layout
+             * See https://tailwindcss.com/docs/table-layout
+             */
+            new ClassGroup( "table-layout", "table", ["auto", "fixed"] ),
+            /*
+             * Caption Side
+             * See https://tailwindcss.com/docs/caption-side
+             */
+            new ClassGroup( "caption", "caption", ["top", "bottom"] ),
+            /*
+             * Transition Property
+             * See https://tailwindcss.com/docs/transition-property
+             */
+            new ClassGroup( "transition", "transition", ["none", "all", "", "colors", "opacity", "shadow", "transform", Validators.IsArbitraryValue] ),
+            /*
+             * Transition Duration
+             * See https://tailwindcss.com/docs/transition-duration
+             */
+            new ClassGroup( "duration", "duration", numberAndArbitrary ),
+            /*
+             * Transition Timing Function
+             * See https://tailwindcss.com/docs/transition-timing-function
+             */
+            new ClassGroup( "ease", "ease", ["linear", "in", "out", "in-out", Validators.IsArbitraryValue] ),
+            /*
+             * Transition Delay
+             * See https://tailwindcss.com/docs/transition-delay
+             */
+            new ClassGroup( "delay", "delay", numberAndArbitrary ),
+            /*
+             * Animation
+             * See https://tailwindcss.com/docs/animation
+             */
+            new ClassGroup( "animate", "animate", ["none", "spin", "ping", "pulse", "bounce", Validators.IsArbitraryValue] ),
+            /*
+             * Transform
+             * See https://tailwindcss.com/docs/transform
+             */
+            new ClassGroup( "transform", "transform", ["", "gpu", "none"] ),
+            /*
+             * Scale
+             * See https://tailwindcss.com/docs/scale
+             */
+            new ClassGroup( "scale", "scale", [scale] ),
+            /*
+             * Scale X
+             * See https://tailwindcss.com/docs/scale
+             */
+            new ClassGroup( "scale-x", "scale-x", [scale] ),
+            /*
+             * Scale Y
+             * See https://tailwindcss.com/docs/scale
+             */
+            new ClassGroup( "scale-y", "scale-y", [scale] ),
+            /*
+             * Rotate
+             * See https://tailwindcss.com/docs/rotate
+             */
+            new ClassGroup( "rotate", "rotate", [Validators.IsInteger, Validators.IsArbitraryValue] ),
+            /*
+             * Translate X
+             * See https://tailwindcss.com/docs/translate
+             */
+            new ClassGroup( "translate-x", "translate-x", [translate] ),
+            /*
+             * Translate Y
+             * See https://tailwindcss.com/docs/translate
+             */
+            new ClassGroup( "translate-y", "translate-y", [translate] ),
+            /*
+             * Skew X
+             * See https://tailwindcss.com/docs/skew
+             */
+            new ClassGroup( "skew-x", "skew-x", [skew] ),
+            /*
+             * Skew Y
+             * See https://tailwindcss.com/docs/skew
+             */
+            new ClassGroup( "skew-y", "skew-y", [skew] ),
+            /*
+             * Transform Origin
+             * See https://tailwindcss.com/docs/transform-origin
+             */
+            new ClassGroup( "transform-origin", "origin", [
+                "center",
+                "top",
+                "top-right",
+                "right",
+                "bottom-right",
+                "bottom",
+                "bottom-left",
+                "left",
+                "top-left",
+                Validators.IsArbitraryValue] ),
+            /*
+             * Accent
+             * See https://tailwindcss.com/docs/accent
+             */
+            new ClassGroup( "accent", "accent", ["auto", colors] ),
+            /*
+             * Appearance
+             * See https://tailwindcss.com/docs/appearance
+             */
+            new ClassGroup( "appearance", "appearance", autoAndNone ),
+            /*
+             * Cursor
+             * See https://tailwindcss.com/docs/cursor
+             */
+            new ClassGroup( "cursor", "cursor", [
+                "auto",
+                "default",
+                "pointer",
+                "wait",
+                "text",
+                "move",
+                "help",
+                "not-allowed",
+                "none",
+                "context-menu",
+                "progress",
+                "cell",
+                "crosshair",
+                "vertical-text",
+                "alias",
+                "copy",
+                "no-drop",
+                "grab",
+                "grabbing",
+                "all-scroll",
+                "col-resize",
+                "row-resize",
+                "n-resize",
+                "e-resize",
+                "s-resize",
+                "w-resize",
+                "ne-resize",
+                "nw-resize",
+                "se-resize",
+                "sw-resize",
+                "ew-resize",
+                "ns-resize",
+                "nesw-resize",
+                "nwse-resize",
+                "zoom-in",
+                "zoom-out",
+                Validators.IsArbitraryValue] ),
+            /*
+             * Caret Color
+             * See https://tailwindcss.com/docs/caret-color
+             */
+            new ClassGroup( "caret-color", "caret", [colors] ),
+            /*
+             * Pointer Events
+             * See https://tailwindcss.com/docs/pointer-events
+             */
+            new ClassGroup( "pointer-events", "pointer-events", autoAndNone ),
+            /*
+             * Resize
+             * See https://tailwindcss.com/docs/resize
+             */
+            new ClassGroup( "resize", "resize", ["none", "y", "x", ""] ),
+            /*
+             * Scroll Behavior
+             * See https://tailwindcss.com/docs/scroll-behavior
+             */
+            new ClassGroup( "scroll-behavior", "scroll", ["auto", "smooth"] ),
+            /*
+             * Scroll Margin
+             * See https://tailwindcss.com/docs/scroll-margin
+             */
+            new ClassGroup( "scroll-m", "scroll-m", spacingWithArbitrary ),
+            /*
+             * Scroll Margin X
+             * See https://tailwindcss.com/docs/scroll-margin
+             */
+            new ClassGroup( "scroll-mx", "scroll-mx", spacingWithArbitrary ),
+            /*
+             * Scroll Margin Y
+             * See https://tailwindcss.com/docs/scroll-margin
+             */
+            new ClassGroup( "scroll-my", "scroll-my", spacingWithArbitrary ),
+            /*
+             * Scroll Margin Start
+             * See https://tailwindcss.com/docs/scroll-margin
+             */
+            new ClassGroup( "scroll-ms", "scroll-ms", spacingWithArbitrary ),
+            /*
+             * Scroll Margin End
+             * See https://tailwindcss.com/docs/scroll-margin
+             */
+            new ClassGroup( "scroll-me", "scroll-me", spacingWithArbitrary ),
+            /*
+             * Scroll Margin Top
+             * See https://tailwindcss.com/docs/scroll-margin
+             */
+            new ClassGroup( "scroll-mt", "scroll-mt", spacingWithArbitrary ),
+            /*
+             * Scroll Margin Right
+             * See https://tailwindcss.com/docs/scroll-margin
+             */
+            new ClassGroup( "scroll-mr", "scroll-mr", spacingWithArbitrary ),
+            /*
+             * Scroll Margin Bottom
+             * See https://tailwindcss.com/docs/scroll-margin
+             */
+            new ClassGroup( "scroll-mb", "scroll-mb", spacingWithArbitrary ),
+            /*
+             * Scroll Margin Left
+             * See https://tailwindcss.com/docs/scroll-margin
+             */
+            new ClassGroup( "scroll-ml", "scroll-ml", spacingWithArbitrary ),
+            /*
+             * Scroll Padding
+             * See https://tailwindcss.com/docs/scroll-padding
+             */
+            new ClassGroup( "scroll-p", "scroll-p", spacingWithArbitrary ),
+            /*
+             * Scroll Padding X
+             * See https://tailwindcss.com/docs/scroll-padding
+             */
+            new ClassGroup( "scroll-px", "scroll-px", spacingWithArbitrary ),
+            /*
+             * Scroll Padding Y
+             * See https://tailwindcss.com/docs/scroll-padding
+             */
+            new ClassGroup( "scroll-py", "scroll-py", spacingWithArbitrary ),
+            /*
+             * Scroll Padding Start
+             * See https://tailwindcss.com/docs/scroll-padding
+             */
+            new ClassGroup( "scroll-ps", "scroll-ps", spacingWithArbitrary ),
+            /*
+             * Scroll Padding End
+             * See https://tailwindcss.com/docs/scroll-padding
+             */
+            new ClassGroup( "scroll-pe", "scroll-pe", spacingWithArbitrary ),
+            /*
+             * Scroll Padding Top
+             * See https://tailwindcss.com/docs/scroll-padding
+             */
+            new ClassGroup( "scroll-pt", "scroll-pt", spacingWithArbitrary ),
+            /*
+             * Scroll Padding Right
+             * See https://tailwindcss.com/docs/scroll-padding
+             */
+            new ClassGroup( "scroll-pr", "scroll-pr", spacingWithArbitrary ),
+            /*
+             * Scroll Padding Bottom
+             * See https://tailwindcss.com/docs/scroll-padding
+             */
+            new ClassGroup( "scroll-pb", "scroll-pb", spacingWithArbitrary ),
+            /*
+             * Scroll Padding Left
+             * See https://tailwindcss.com/docs/scroll-padding
+             */
+            new ClassGroup( "scroll-pl", "scroll-pl", spacingWithArbitrary ),
+            /*
+             * Scroll Snap Align
+             * See https://tailwindcss.com/docs/scroll-snap-align
+             */
+            new ClassGroup( "snap-align", "snap", ["start", "end", "center", "align-none"] ),
+            /*
+             * Scroll Snap Stop
+             * See https://tailwindcss.com/docs/scroll-snap-stop
+             */
+            new ClassGroup( "snap-stop", "snap", ["normal", "always"] ),
+            /*
+             * Scroll Snap Type
+             * See https://tailwindcss.com/docs/scroll-snap-type
+             */
+            new ClassGroup( "snap-type", "snap", ["none", "x", "y", "both"] ),
+            /*
+             * Scroll Snap Type Strictness
+             * See https://tailwindcss.com/docs/scroll-snap-type
+             */
+            new ClassGroup( "snap-strictness", "snap", ["mandatory", "proximity"] ),
+            /*
+             * Touch Action
+             * See https://tailwindcss.com/docs/touch-action
+             */
+            new ClassGroup( "touch", "touch", ["auto", "none", "manipulation"] ),
+            /*
+             * Touch Action X
+             * See https://tailwindcss.com/docs/touch-action
+             */
+            new ClassGroup( "touch-x", "touch-pan", ["x", "left", "right"] ),
+            /*
+             * Touch Action Y
+             * See https://tailwindcss.com/docs/touch-action
+             */
+            new ClassGroup( "touch-y", "touch-pan", ["y", "up", "down"] ),
+            /*
+             * Touch Action Pinch Zoom
+             * See https://tailwindcss.com/docs/touch-action
+             */
+            new ClassGroup( "touch-pz", ["touch-pinch-zoom"] ),
+            /*
+             * User Select
+             * See https://tailwindcss.com/docs/user-select
+             */
+            new ClassGroup( "select", "select", ["none", "text", "all", "auto"] ),
+            /*
+             * Will Change
+             * See https://tailwindcss.com/docs/will-change
+             */
+            new ClassGroup( "will-change", "will-change", ["auto", "scroll", "contents", "transform", Validators.IsArbitraryValue] ),
+            /*
+             * Fill
+             * See https://tailwindcss.com/docs/fill
+             */
+            new ClassGroup( "fill", "fill", ["none", colors] ),
+            /*
+             * Stroke Width
+             * See https://tailwindcss.com/docs/stroke-width
+             */
+            new ClassGroup( "stroke-w", "stroke", [Validators.IsLength, Validators.IsArbitraryLength, Validators.IsArbitraryNumber] ),
+            /*
+             * Stroke
+             * See https://tailwindcss.com/docs/stroke
+             */
+            new ClassGroup( "stroke", "stroke", ["none", colors] ),
+            /*
+             * Screen Readers
+             * See https://tailwindcss.com/docs/screen-readers
+             */
+            new ClassGroup( "sr", ["sr-only", "not-sr-only"] ),
+            /*
+             * Forced Color Adjust
+             * See https://tailwindcss.com/docs/forced-color-adjust
+             */
+            new ClassGroup( "forced-color-adjust", "forced-color-adjust", autoAndNone )
+        ];
+
         ConflictingClassGroups = _conflictingClassGroups.AsReadOnly();
         ConflictingClassGroupModifiers = _conflictingClassGroupModifiers.AsReadOnly();
     }
@@ -1703,8 +1739,25 @@ public class TwMergeConfig
     /// Creates a new instance of the <see cref="TwMergeConfig"/> class with default settings.
     /// </summary>
     /// <returns>A <see cref="TwMergeConfig"/> instance.</returns>
-    public static TwMergeConfig Default()
+    public static TwMergeConfig Default() => new();
+
+    /// <summary>
+    /// Extends the current configuration with additional class groups.
+    /// </summary>
+    /// <param name="classGroups">An array of class groups to be added to the configuration.</param>
+    /// <returns>A <see cref="TwMergeConfig"/> instance.</returns>
+    /// <exception cref="ArgumentException">Thrown if any class group Id does not exist in the list of supported class group keys.</exception>
+    public void Extend( ExtendedConfig extendedConfig )
     {
-        return new();
+        if( extendedConfig.Theme is not null )
+        {
+            foreach( var (key, values) in extendedConfig.Theme )
+            {
+                if( Theme.TryGetValue( key, out var initialValues ) )
+                {
+                    Theme[key] = [.. initialValues, .. values];
+                }
+            }
+        }
     }
 }

--- a/src/TwMergeConfig.cs
+++ b/src/TwMergeConfig.cs
@@ -1792,16 +1792,16 @@ public class TwMergeConfig
                 return;
             }
 
-            foreach( var (key, value) in extendDict )
+            foreach( var (classGroupId, classGroup) in extendDict )
             {
-                if( ClassGroups.TryGetValue( key, out var existingGroup ) )
+                if( ClassGroups.TryGetValue( classGroupId, out var existingGroup ) )
                 {
-                    var mergedDefinitions = MergeArrays( existingGroup.Definitions, value.Definitions );
-                    ClassGroups[key] = new ClassGroup( value.BaseClassName, mergedDefinitions );
+                    var mergedDefinitions = MergeArrays( existingGroup.Definitions, classGroup.Definitions );
+                    ClassGroups[classGroupId] = new ClassGroup( classGroup.BaseClassName, mergedDefinitions );
                 }
                 else
                 {
-                    ClassGroups[key] = value;
+                    ClassGroups[classGroupId] = classGroup;
                 }
             }
         }
@@ -1834,9 +1834,9 @@ public class TwMergeConfig
                 return;
             }
 
-            foreach( var (key, values) in overrideDict )
+            foreach( var (key, value) in overrideDict )
             {
-                originalDict[key] = values;
+                originalDict[key] = value;
             }
         }
     }

--- a/src/TwMergeConfig.cs
+++ b/src/TwMergeConfig.cs
@@ -3,7 +3,10 @@ using TailwindMerge.Models;
 
 namespace TailwindMerge;
 
-internal class TwMergeConfig
+/// <summary>
+/// Represents the configuration settings for the <see cref="TwMerge"/>.
+/// </summary>
+public class TwMergeConfig
 {
     private static readonly Func<string, bool>[] _any = [Validators.IsAny];
     private static readonly Func<string, bool>[] _arbitraryValue = [Validators.IsArbitraryValue];
@@ -1657,14 +1660,37 @@ internal class TwMergeConfig
         ["font-size"] = ["leading"]
     };
 
-    internal int CacheSize{ get; }
-    internal string Separator { get; }
+    /// <summary>
+    /// Gets the maximum size of the internal LRU cache.
+    /// </summary>
+    /// <remarks>
+    /// The default is 500
+    /// </remarks>
+    public int CacheSize { get; init; }
+
+    /// <summary>
+    /// Gets the <seealso href="https://tailwindcss.com/docs/configuration#separator">separator</seealso> that is used to separate 
+    /// modifiers (e.g., screen sizes, hover, focus, etc.) from utility names.
+    /// </summary>
+    /// <remarks>
+    /// The default is <c>:</c>
+    /// </remarks>
+    public string Separator { get; init; }
+
+    /// <summary>
+    /// Gets the <seealso href="https://tailwindcss.com/docs/configuration#prefix">prefix</seealso> that allows
+    /// you to add a custom prefix to all of Tailwind’s generated utility classes.
+    /// </summary>
+    public string? Prefix { get; init; }
+
     internal ClassGroup[] ClassGroups { get; }
-    // Is it worth using FrozenDictionary here?
     internal IReadOnlyDictionary<string, string[]> ConflictingClassGroups { get; }
     internal IReadOnlyDictionary<string, string[]> ConflictingClassGroupModifiers { get; }
 
-    internal TwMergeConfig()
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TwMergeConfig"/> class.
+    /// </summary>
+    public TwMergeConfig()
     {
         CacheSize = 500;
         Separator = ":";
@@ -1673,7 +1699,11 @@ internal class TwMergeConfig
         ConflictingClassGroupModifiers = _conflictingClassGroupModifiers.AsReadOnly();
     }
 
-    internal static TwMergeConfig Default()
+    /// <summary>
+    /// Creates a new instance of the <see cref="TwMergeConfig"/> class with default settings.
+    /// </summary>
+    /// <returns>A <see cref="TwMergeConfig"/> instance.</returns>
+    public static TwMergeConfig Default()
     {
         return new();
     }

--- a/src/TwMergeConfig.cs
+++ b/src/TwMergeConfig.cs
@@ -1742,11 +1742,9 @@ public class TwMergeConfig
     public static TwMergeConfig Default() => new();
 
     /// <summary>
-    /// Extends the current configuration with additional class groups.
+    /// Extends the current configuration with the values from the provided <see cref="ExtendedConfig"/>.
     /// </summary>
-    /// <param name="classGroups">An array of class groups to be added to the configuration.</param>
-    /// <returns>A <see cref="TwMergeConfig"/> instance.</returns>
-    /// <exception cref="ArgumentException">Thrown if any class group Id does not exist in the list of supported class group keys.</exception>
+    /// <param name="extendedConfig">The extended configuration.</param>
     public void Extend( ExtendedConfig extendedConfig )
     {
         if( extendedConfig.Theme is not null )

--- a/src/TwMergeConfig.cs
+++ b/src/TwMergeConfig.cs
@@ -138,11 +138,15 @@ public class TwMergeConfig
     public string? Prefix { get; set; }
 
     /// <summary>
-    /// Gets or sets the theme configuration.
+    /// Gets or sets the theme of the configuration.
     /// </summary>
     public Dictionary<string, object[]> Theme { get; set; }
 
-    internal ClassGroup[] ClassGroups { get; init; }
+    /// <summary>
+    /// Gets or sets the class groups of the configuration.
+    /// </summary>
+    public ClassGroup[] ClassGroups { get; set; }
+
     internal IReadOnlyDictionary<string, string[]> ConflictingClassGroups { get; }
     internal IReadOnlyDictionary<string, string[]> ConflictingClassGroupModifiers { get; }
 
@@ -154,31 +158,31 @@ public class TwMergeConfig
         CacheSize = 500;
         Separator = ":";
 
-        var colors = () => Theme?["colors"];
-        var spacing = () => Theme?["spacing"];
-        var blur = () => Theme?["blur"];
-        var brightness = () => Theme?["brightness"];
-        var borderColor = () => Theme?["borderColor"];
-        var borderRadius = () => Theme?["borderRadius"];
-        var borderSpacing = () => Theme?["borderSpacing"];
-        var borderWidth = () => Theme?["borderWidth"];
-        var contrast = () => Theme?["contrast"];
-        var grayscale = () => Theme?["grayscale"];
-        var hueRotate = () => Theme?["hueRotate"];
-        var invert = () => Theme?["invert"];
-        var gap = () => Theme?["gap"];
-        var gradientColorStops = () => Theme?["gradientColorStops"];
-        var gradientColorStopPositions = () => Theme?["gradientColorStopPositions"];
-        var inset = () => Theme?["inset"];
-        var margin = () => Theme?["margin"];
-        var opacity = () => Theme?["opacity"];
-        var padding = () => Theme?["padding"];
-        var saturate = () => Theme?["saturate"];
-        var scale = () => Theme?["scale"];
-        var sepia = () => Theme?["sepia"];
-        var skew = () => Theme?["skew"];
-        var space = () => Theme?["space"];
-        var translate = () => Theme?["translate"];
+        var colors = ThemeUtility.FromTheme( "colors" );
+        var spacing = ThemeUtility.FromTheme( "spacing" );
+        var blur = ThemeUtility.FromTheme( "blur" );
+        var brightness = ThemeUtility.FromTheme( "brightness" );
+        var borderColor = ThemeUtility.FromTheme( "borderColor" );
+        var borderRadius = ThemeUtility.FromTheme( "borderRadius" );
+        var borderSpacing = ThemeUtility.FromTheme( "borderSpacing" );
+        var borderWidth = ThemeUtility.FromTheme( "borderWidth" );
+        var contrast = ThemeUtility.FromTheme( "contrast" );
+        var grayscale = ThemeUtility.FromTheme( "grayscale" );
+        var hueRotate = ThemeUtility.FromTheme( "hueRotate" );
+        var invert = ThemeUtility.FromTheme( "invert" );
+        var gap = ThemeUtility.FromTheme( "gap" );
+        var gradientColorStops = ThemeUtility.FromTheme( "gradientColorStops" );
+        var gradientColorStopPositions = ThemeUtility.FromTheme( "gradientColorStopPositions" );
+        var inset = ThemeUtility.FromTheme( "inset" );
+        var margin = ThemeUtility.FromTheme( "margin" );
+        var opacity = ThemeUtility.FromTheme( "opacity" );
+        var padding = ThemeUtility.FromTheme( "padding" );
+        var saturate = ThemeUtility.FromTheme( "saturate" );
+        var scale = ThemeUtility.FromTheme( "scale" );
+        var sepia = ThemeUtility.FromTheme( "sepia" );
+        var skew = ThemeUtility.FromTheme( "skew" );
+        var space = ThemeUtility.FromTheme( "space" );
+        var translate = ThemeUtility.FromTheme( "translate" );
 
         object[] any = [Validators.IsAny];
         object[] number = [Validators.IsNumber, Validators.IsArbitraryNumber];
@@ -220,6 +224,7 @@ public class TwMergeConfig
             ["spacing"] = [Validators.IsLength, Validators.IsArbitraryLength],
             ["blur"] = ["none", "", Validators.IsTshirtSize, Validators.IsArbitraryValue],
             ["brightness"] = number,
+            ["borderColor"] = [colors],
             ["borderRadius"] = ["none", "", "full", Validators.IsTshirtSize, Validators.IsArbitraryValue],
             ["borderSpacing"] = spacingWithArbitrary,
             ["borderWidth"] = lengthWithEmptyAndArbitrary,
@@ -228,6 +233,7 @@ public class TwMergeConfig
             ["hueRotate"] = numberAndArbitrary,
             ["invert"] = zeroAndEmpty,
             ["gap"] = spacingWithArbitrary,
+            ["gradientColorStops"] = [colors],
             ["gradientColorStopPositions"] = [Validators.IsPercent, Validators.IsArbitraryLength],
             ["inset"] = spacingWithAutoAndArbitrary,
             ["margin"] = spacingWithAutoAndArbitrary,
@@ -240,10 +246,6 @@ public class TwMergeConfig
             ["space"] = spacingWithArbitrary,
             ["translate"] = spacingWithArbitrary
         };
-
-        // No way to reference the same object during initialization
-        Theme["borderColor"] = colors();
-        Theme["gradientColorStops"] = colors();
 
         ClassGroups = [
             /*
@@ -1755,7 +1757,22 @@ public class TwMergeConfig
                 {
                     Theme[key] = [.. initialValues, .. values];
                 }
+                else
+                {
+                    Theme[key] = values;
+                }
             }
+        }
+        if( extendedConfig.ClassGroups is { Length: > 0 } )
+        {
+            var classGroupsLength = ClassGroups.Length;
+            var extendedClassGroupsLength = extendedConfig.ClassGroups.Length;
+            var mergedClassGroups = new ClassGroup[classGroupsLength + extendedClassGroupsLength];
+
+            Array.Copy( ClassGroups, mergedClassGroups, classGroupsLength );
+            Array.Copy( extendedConfig.ClassGroups, 0, mergedClassGroups, classGroupsLength, extendedClassGroupsLength );
+
+            ClassGroups = mergedClassGroups;
         }
     }
 }

--- a/src/TwMergeConfig.cs
+++ b/src/TwMergeConfig.cs
@@ -8,112 +8,6 @@ namespace TailwindMerge;
 /// </summary>
 public class TwMergeConfig
 {
-    private static readonly Dictionary<string, string[]> _conflictingClassGroups = new( 46 )
-    {
-        ["overflow"] = ["overflow-x", "overflow-y"],
-        ["overscroll"] = ["overscroll-x", "overscroll-y"],
-        ["inset"] = ["inset-x", "inset-y", "start", "end", "top", "right", "bottom", "left"],
-        ["inset-x"] = ["right", "left"],
-        ["inset-y"] = ["top", "bottom"],
-        ["flex"] = ["basis", "grow", "shrink"],
-        ["gap"] = ["gap-x", "gap-y"],
-        ["p"] = ["px", "py", "ps", "pe", "pt", "pr", "pb", "pl"],
-        ["px"] = ["pr", "pl"],
-        ["py"] = ["pt", "pb"],
-        ["m"] = ["mx", "my", "ms", "me", "mt", "mr", "mb", "ml"],
-        ["mx"] = ["mr", "ml"],
-        ["my"] = ["mt", "mb"],
-        ["size"] = ["w", "h"],
-        ["font-size"] = ["leading"],
-        ["fvn-normal"] = [
-            "fvn-ordinal",
-            "fvn-slashed-zero",
-            "fvn-figure",
-            "fvn-spacing",
-            "fvn-fraction"
-        ],
-        ["fvn-ordinal"] = ["fvn-normal"],
-        ["fvn-slashed-zero"] = ["fvn-normal"],
-        ["fvn-figure"] = ["fvn-normal"],
-        ["fvn-spacing"] = ["fvn-normal"],
-        ["fvn-fraction"] = ["fvn-normal"],
-        ["line-clamp"] = ["display", "overflow"],
-        ["rounded"] = [
-            "rounded-s",
-            "rounded-e",
-            "rounded-t",
-            "rounded-r",
-            "rounded-b",
-            "rounded-l",
-            "rounded-ss",
-            "rounded-se",
-            "rounded-ee",
-            "rounded-es",
-            "rounded-tl",
-            "rounded-tr",
-            "rounded-br",
-            "rounded-bl"
-        ],
-        ["rounded-s"] = ["rounded-ss", "rounded-es"],
-        ["rounded-e"] = ["rounded-se", "rounded-ee"],
-        ["rounded-t"] = ["rounded-tl", "rounded-tr"],
-        ["rounded-r"] = ["rounded-tr", "rounded-br"],
-        ["rounded-b"] = ["rounded-br", "rounded-bl"],
-        ["rounded-l"] = ["rounded-tl", "rounded-bl"],
-        ["border-spacing"] = ["border-spacing-x", "border-spacing-y"],
-        ["border-w"] = [
-            "border-w-s",
-            "border-w-e",
-            "border-w-t",
-            "border-w-r",
-            "border-w-b",
-            "border-w-l"
-        ],
-        ["border-w-x"] = ["border-w-r", "border-w-l"],
-        ["border-w-y"] = ["border-w-t", "border-w-b"],
-        ["border-color"] = [
-            "border-color-t",
-            "border-color-r",
-            "border-color-b",
-            "border-color-l"
-        ],
-        ["border-color-x"] = ["border-color-r", "border-color-l"],
-        ["border-color-y"] = ["border-color-t", "border-color-b"],
-        ["scroll-m"] = [
-            "scroll-mx",
-            "scroll-my",
-            "scroll-ms",
-            "scroll-me",
-            "scroll-mt",
-            "scroll-mr",
-            "scroll-mb",
-            "scroll-ml"
-        ],
-        ["scroll-mx"] = ["scroll-mr", "scroll-ml"],
-        ["scroll-my"] = ["scroll-mt", "scroll-mb"],
-        ["scroll-p"] = [
-            "scroll-px",
-            "scroll-py",
-            "scroll-ps",
-            "scroll-pe",
-            "scroll-pt",
-            "scroll-pr",
-            "scroll-pb",
-            "scroll-pl"
-        ],
-        ["scroll-px"] = ["scroll-pr", "scroll-pl"],
-        ["scroll-py"] = ["scroll-pt", "scroll-pb"],
-        ["touch"] = ["touch-x", "touch-y", "touch-pz"],
-        ["touch-x"] = ["touch"],
-        ["touch-y"] = ["touch"],
-        ["touch-pz"] = ["touch"]
-    };
-
-    private static readonly Dictionary<string, string[]> _conflictingClassGroupModifiers = new( 1 )
-    {
-        ["font-size"] = ["leading"]
-    };
-
     /// <summary>
     /// Gets or sets the maximum size of the LRU cache used for memoizing results.
     /// </summary>
@@ -138,17 +32,24 @@ public class TwMergeConfig
     public string? Prefix { get; set; }
 
     /// <summary>
+    /// Gets or sets the class groups of the configuration.
+    /// </summary>
+    public Dictionary<string, ClassGroup> ClassGroups { get; set; }
+
+    /// <summary>
+    /// Gets or sets the conflicting class groups of the configuration.
+    /// </summary>
+    public Dictionary<string, string[]> ConflictingClassGroups { get; set; }
+
+    /// <summary>
+    /// Gets or sets the conflicting class group modifiers of the configuration.
+    /// </summary>
+    public Dictionary<string, string[]> ConflictingClassGroupModifiers { get; set; }
+
+    /// <summary>
     /// Gets or sets the theme of the configuration.
     /// </summary>
     public Dictionary<string, object[]> Theme { get; set; }
-
-    /// <summary>
-    /// Gets or sets the class groups of the configuration.
-    /// </summary>
-    public ClassGroup[] ClassGroups { get; set; }
-
-    internal IReadOnlyDictionary<string, string[]> ConflictingClassGroups { get; }
-    internal IReadOnlyDictionary<string, string[]> ConflictingClassGroupModifiers { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TwMergeConfig"/> class.
@@ -218,7 +119,7 @@ public class TwMergeConfig
         string[] overflow = ["auto", "hidden", "clip", "visible", "scroll"];
         string[] positions = ["bottom", "center", "left", "left-bottom", "left-top", "right", "right-bottom", "right-top", "top"];
 
-        Theme = new()
+        Theme = new( 25 )
         {
             ["colors"] = [Validators.IsAny],
             ["spacing"] = [Validators.IsLength, Validators.IsArbitraryLength],
@@ -247,52 +148,53 @@ public class TwMergeConfig
             ["translate"] = spacingWithArbitrary
         };
 
-        ClassGroups = [
+        ClassGroups = new( 270 )
+        {
             /*
             * Aspect Ratio
             * See https://tailwindcss.com/docs/aspect-ratio
             */
-            new ClassGroup( "aspect", "aspect", ["auto", "square", "video", Validators.IsArbitraryValue] ),
+            ["aspect"] = new ClassGroup( "aspect", ["auto", "square", "video", Validators.IsArbitraryValue] ),
             /*
              * Container
              * See https://tailwindcss.com/docs/container
              */
-            new ClassGroup( "container", ["container"] ),
+            ["container"] = new ClassGroup( ["container"] ),
             /*
              * Columns
              * See https://tailwindcss.com/docs/columns
              */
-            new ClassGroup( "columns", "columns", [Validators.IsTshirtSize] ),
+            ["columns"] = new ClassGroup( "columns", [Validators.IsTshirtSize] ),
             /*
              * Break After
              * See https://tailwindcss.com/docs/break-after
              */
-            new ClassGroup( "break-after", "break-after", breaks ),
+            ["break-after"] = new ClassGroup( "break-after", breaks ),
             /*
              * Break Before
              * See https://tailwindcss.com/docs/break-before
              */
-            new ClassGroup( "break-before", "break-before", breaks ),
+            ["break-before"] = new ClassGroup( "break-before", breaks ),
             /*
              * Break Inside
              * See https://tailwindcss.com/docs/break-inside
              */
-            new ClassGroup( "break-inside", "break-inside", ["auto", "avoid", "avoid-page", "avoid-column"] ),
+            ["break-inside"] = new ClassGroup( "break-inside", ["auto", "avoid", "avoid-page", "avoid-column"] ),
             /*
              * Box Decoration Break
              * See https://tailwindcss.com/docs/box-decoration-break
              */
-            new ClassGroup( "box-decoration", "box-decoration", ["slice", "clone"] ),
+            ["box-decoration"] = new ClassGroup( "box-decoration", ["slice", "clone"] ),
             /*
              * Box Sizing
              * See https://tailwindcss.com/docs/box-sizing
              */
-            new ClassGroup( "box", "box", ["border", "content"] ),
+            ["box"] = new ClassGroup( "box", ["border", "content"] ),
             /*
              * Display
              * See https://tailwindcss.com/docs/display
              */
-            new ClassGroup( "display", [
+            ["display"] = new ClassGroup( [
                 "block",
                 "inline-block",
                 "inline",
@@ -318,447 +220,447 @@ public class TwMergeConfig
              * Floats
              * See https://tailwindcss.com/docs/float
              */
-            new ClassGroup( "float", "float", ["right", "left", "none", "start", "end"] ),
+            ["float"] = new ClassGroup( "float", ["right", "left", "none", "start", "end"] ),
             /*
              * Clear
              * See https://tailwindcss.com/docs/clear
              */
-            new ClassGroup( "clear", "clear", ["left", "right", "both", "none", "start", "end"] ),
+            ["clear"] = new ClassGroup( "clear", ["left", "right", "both", "none", "start", "end"] ),
             /*
              * Isolation
              * See https://tailwindcss.com/docs/isolation
              */
-            new ClassGroup( "isolation", ["isolate", "isolation-auto"] ),
+            ["isolation"] = new ClassGroup( ["isolate", "isolation-auto"] ),
             /*
              * Object Fit
              * See https://tailwindcss.com/docs/object-fit
              */
-            new ClassGroup( "object-fit", "object", ["contain", "cover", "fill", "none", "scale-down"] ),
+            ["object-fit"] = new ClassGroup( "object", ["contain", "cover", "fill", "none", "scale-down"] ),
             /*
              * Object Position
              * See https://tailwindcss.com/docs/object-position
              */
-            new ClassGroup( "object-position", "object", [.. positions, Validators.IsArbitraryValue] ),
+            ["object-position"] = new ClassGroup( "object", [.. positions, Validators.IsArbitraryValue] ),
             /*
              * Overflow
              * See https://tailwindcss.com/docs/overflow
              */
-            new ClassGroup( "overflow", "overflow", overflow ),
+            ["overflow"] = new ClassGroup( "overflow", overflow ),
             /*
              * Overflow X
              * See https://tailwindcss.com/docs/overflow
              */
-            new ClassGroup( "overflow-x", "overflow-x", overflow ),
+            ["overflow-x"] = new ClassGroup( "overflow-x", overflow ),
             /*
              * Overflow Y
              * See https://tailwindcss.com/docs/overflow
              */
-            new ClassGroup( "overflow-y", "overflow-y", overflow ),
+            ["overflow-y"] = new ClassGroup( "overflow-y", overflow ),
             /*
              * Overscroll Behavior
              * See https://tailwindcss.com/docs/overscroll-behavior
              */
-            new ClassGroup( "overscroll", "overscroll", overscroll ),
+            ["overscroll"] = new ClassGroup( "overscroll", overscroll ),
             /*
              * Overscroll Behavior X
              * See https://tailwindcss.com/docs/overscroll-behavior
              */
-            new ClassGroup( "overscroll-x", "overscroll-x", overscroll ),
+            ["overscroll-x"] = new ClassGroup( "overscroll-x", overscroll ),
             /*
              * Overscroll Behavior Y
              * See https://tailwindcss.com/docs/overscroll-behavior
              */
-            new ClassGroup( "overscroll-y", "overscroll-y", overscroll ),
+            ["overscroll-y"] = new ClassGroup( "overscroll-y", overscroll ),
             /*
              * Position
              * See https://tailwindcss.com/docs/position
              */
-            new ClassGroup( "position", ["static", "fixed", "absolute", "relative", "sticky"] ),
+            ["position"] = new ClassGroup( ["static", "fixed", "absolute", "relative", "sticky"] ),
             /*
              * Top / Right / Bottom / Left
              * See https://tailwindcss.com/docs/top-right-bottom-left
              */
-            new ClassGroup( "inset", "inset", [inset] ),
+            ["inset"] = new ClassGroup( "inset", [inset] ),
             /*
              * Right / Left
              * See https://tailwindcss.com/docs/top-right-bottom-left
              */
-            new ClassGroup( "inset-x", "inset-x", [inset] ),
+            ["inset-x"] = new ClassGroup( "inset-x", [inset] ),
             /*
              * Top / Bottom
              * See https://tailwindcss.com/docs/top-right-bottom-left
              */
-            new ClassGroup( "inset-y", "inset-y", [inset] ),
+            ["inset-y"] = new ClassGroup( "inset-y", [inset] ),
             /*
              * Start
              * See https://tailwindcss.com/docs/top-right-bottom-left
              */
-            new ClassGroup( "start", "start", [inset] ),
+            ["start"] = new ClassGroup( "start", [inset] ),
             /*
              * End
              * See https://tailwindcss.com/docs/top-right-bottom-left
              */
-            new ClassGroup( "end", "end", [inset] ),
+            ["end"] = new ClassGroup( "end", [inset] ),
             /*
              * Top
              * See https://tailwindcss.com/docs/top-right-bottom-left
              */
-            new ClassGroup( "top", "top", [inset] ),
+            ["top"] = new ClassGroup( "top", [inset] ),
             /*
              * Right
              * See https://tailwindcss.com/docs/top-right-bottom-left
              */
-            new ClassGroup( "right", "right", [inset] ),
+            ["right"] = new ClassGroup( "right", [inset] ),
             /*
              * Bottom
              * See https://tailwindcss.com/docs/top-right-bottom-left
              */
-            new ClassGroup( "bottom", "bottom", [inset] ),
+            ["bottom"] = new ClassGroup( "bottom", [inset] ),
             /*
              * Left
              * See https://tailwindcss.com/docs/top-right-bottom-left
              */
-            new ClassGroup( "left", "left", [inset] ),
+            ["left"] = new ClassGroup( "left", [inset] ),
             /*
              * Visibility
              * See https://tailwindcss.com/docs/visibility
              */
-            new ClassGroup( "visibility", ["visible", "invisible", "collapse"] ),
+            ["visibility"] = new ClassGroup( ["visible", "invisible", "collapse"] ),
             /*
              * Z-Index
              * See https://tailwindcss.com/docs/z-index
              */
-            new ClassGroup( "z", "z", ["auto", Validators.IsInteger, Validators.IsArbitraryValue] ),
+            ["z"] = new ClassGroup( "z", ["auto", Validators.IsInteger, Validators.IsArbitraryValue] ),
             /*
              * Flex Basis
              * See https://tailwindcss.com/docs/flex-basis
              */
-            new ClassGroup( "basis", "basis", spacingWithAutoAndArbitrary ),
+            ["basis"] = new ClassGroup( "basis", spacingWithAutoAndArbitrary ),
             /*
              * Flex Direction
              * See https://tailwindcss.com/docs/flex-direction
              */
-            new ClassGroup( "flex-direction", "flex", ["row", "row-reverse", "col", "col-reverse"] ),
+            ["flex-direction"] = new ClassGroup( "flex", ["row", "row-reverse", "col", "col-reverse"] ),
             /*
              * Flex Wrap
              * See https://tailwindcss.com/docs/flex-wrap
              */
-            new ClassGroup( "flex-wrap", "flex", ["wrap", "wrap-reverse", "nowrap"] ),
+            ["flex-wrap"] = new ClassGroup( "flex", ["wrap", "wrap-reverse", "nowrap"] ),
             /*
              * Flex
              * See https://tailwindcss.com/docs/flex
              */
-            new ClassGroup( "flex", "flex", ["1", "auto", "initial", "none", Validators.IsArbitraryValue] ),
+            ["flex"] = new ClassGroup( "flex", ["1", "auto", "initial", "none", Validators.IsArbitraryValue] ),
             /*
              * Flex Grow
              * See https://tailwindcss.com/docs/flex-grow
              */
-            new ClassGroup( "grow", "grow", zeroAndEmpty ),
+            ["grow"] = new ClassGroup( "grow", zeroAndEmpty ),
             /*
              * Flex Shrink
              * See https://tailwindcss.com/docs/flex-shrink
              */
-            new ClassGroup( "shrink", "shrink", zeroAndEmpty ),
+            ["shrink"] = new ClassGroup( "shrink", zeroAndEmpty ),
             /*
              * Order
              * See https://tailwindcss.com/docs/order
              */
-            new ClassGroup( "order", "order", ["first", "last", "none", Validators.IsInteger, Validators.IsArbitraryValue] ),
+            ["order"] = new ClassGroup( "order", ["first", "last", "none", Validators.IsInteger, Validators.IsArbitraryValue] ),
             /*
              * Grid Template Columns
              * See https://tailwindcss.com/docs/grid-template-columns
              */
-            new ClassGroup( "grid-cols", "grid-cols", any ),
+            ["grid-cols"] = new ClassGroup( "grid-cols", any ),
             /*
              * Grid Column Start / End
              * See https://tailwindcss.com/docs/grid-column
              */
-            new ClassGroup( "col-start-end", "col", ["auto", Validators.IsArbitraryValue] ),
-            /*
-             * Grid Column Span
-             * See https://tailwindcss.com/docs/grid-column
-             */
-            new ClassGroup( "col-start-end", "col-span", ["full", .. numberAndArbitrary] ),
+            ["col-start-end"] = new ClassGroup( "col", [
+                "auto",
+                new ClassGroup( "span", ["full", .. numberAndArbitrary] ),
+                Validators.IsArbitraryValue] ),
             /*
              * Grid Column Start
              * See https://tailwindcss.com/docs/grid-column
              */
-            new ClassGroup( "col-start", "col-start", ["auto", .. numberAndArbitrary] ),
+            ["col-start"] = new ClassGroup( "col-start", ["auto", .. numberAndArbitrary] ),
             /*
              * Grid Column End
              * See https://tailwindcss.com/docs/grid-column
              */
-            new ClassGroup( "col-end", "col-end", ["auto", .. numberAndArbitrary] ),
+            ["col-end"] = new ClassGroup( "col-end", ["auto", .. numberAndArbitrary] ),
             /*
              * Grid Template Rows
              * See https://tailwindcss.com/docs/grid-template-rows
              */
-            new ClassGroup( "grid-rows", "grid-rows", any ),
+            ["grid-rows"] = new ClassGroup( "grid-rows", any ),
             /*
              * Grid Row Start / End
              * See https://tailwindcss.com/docs/grid-row
              */
-            new ClassGroup( "row-start-end", "row", ["auto", Validators.IsArbitraryValue] ),
-            /*
-             * Grid Row Span
-             * See https://tailwindcss.com/docs/grid-row
-             */
-            new ClassGroup( "row-start-end", "row-span", numberAndArbitrary ),
+            ["row-start-end"] = new ClassGroup( "row", [
+                "auto",
+                new ClassGroup( "span", numberAndArbitrary ),
+                Validators.IsArbitraryValue] ),
             /*
              * Grid Row Start
              * See https://tailwindcss.com/docs/grid-row
              */
-            new ClassGroup( "row-start", "row-start", ["auto", .. numberAndArbitrary] ),
+            ["row-start"] = new ClassGroup( "row-start", ["auto", .. numberAndArbitrary] ),
             /*
              * Grid Row End
              * See https://tailwindcss.com/docs/grid-row
              */
-            new ClassGroup( "row-end", "row-end", ["auto", .. numberAndArbitrary] ),
+            ["row-end"] = new ClassGroup( "row-end", ["auto", .. numberAndArbitrary] ),
             /*
              * Grid Auto Flow
              * See https://tailwindcss.com/docs/grid-auto-flow
              */
-            new ClassGroup( "grid-flow", "grid-flow", ["row", "col", "dense", "row-dense", "col-dense"] ),
+            ["grid-flow"] = new ClassGroup( "grid-flow", ["row", "col", "dense", "row-dense", "col-dense"] ),
             /*
              * Grid Auto Columns
              * See https://tailwindcss.com/docs/grid-auto-columns
              */
-            new ClassGroup( "auto-cols", "auto-cols", ["auto", "min", "max", "fr", Validators.IsArbitraryValue] ),
+            ["auto-cols"] = new ClassGroup( "auto-cols", ["auto", "min", "max", "fr", Validators.IsArbitraryValue] ),
             /*
              * Grid Auto Rows
              * See https://tailwindcss.com/docs/grid-auto-rows
              */
-            new ClassGroup( "auto-rows", "auto-rows", ["auto", "min", "max", "fr", Validators.IsArbitraryValue] ),
+            ["auto-rows"] = new ClassGroup( "auto-rows", ["auto", "min", "max", "fr", Validators.IsArbitraryValue] ),
             /*
              * Gap
              * See https://tailwindcss.com/docs/gap
              */
-            new ClassGroup( "gap", "gap", [gap] ),
+            ["gap"] = new ClassGroup( "gap", [gap] ),
             /*
              * Gap X
              * See https://tailwindcss.com/docs/gap
              */
-            new ClassGroup( "gap-x", "gap-x", [gap] ),
+            ["gap-x"] = new ClassGroup( "gap-x", [gap] ),
             /*
              * Gap Y
              * See https://tailwindcss.com/docs/gap
              */
-            new ClassGroup( "gap-y", "gap-y", [gap] ),
+            ["gap-y"] = new ClassGroup( "gap-y", [gap] ),
             /*
              * Justify Content
              * See https://tailwindcss.com/docs/justify-content
              */
-            new ClassGroup( "justify-content", "justify", ["normal", .. align] ),
+            ["justify-content"] = new ClassGroup( "justify", ["normal", .. align] ),
             /*
              * Justify Items
              * See https://tailwindcss.com/docs/justify-items
              */
-            new ClassGroup( "justify-items", "justify-items", ["start", "end", "center", "stretch"] ),
+            ["justify-items"] = new ClassGroup( "justify-items", ["start", "end", "center", "stretch"] ),
             /*
              * Justify Self
              * See https://tailwindcss.com/docs/justify-self
              */
-            new ClassGroup( "justify-self", "justify-self", ["auto", "start", "end", "center", "stretch"] ),
+            ["justify-self"] = new ClassGroup( "justify-self", ["auto", "start", "end", "center", "stretch"] ),
             /*
              * Align Content
              * See https://tailwindcss.com/docs/align-content
              */
-            new ClassGroup( "align-content", "content", ["normal", "baseline", .. align] ),
+            ["align-content"] = new ClassGroup( "content", ["normal", "baseline", .. align] ),
             /*
              * Align Items
              * See https://tailwindcss.com/docs/align-items
              */
-            new ClassGroup( "align-items", "items", ["start", "end", "center", "baseline", "stretch"] ),
+            ["align-items"] = new ClassGroup( "items", ["start", "end", "center", "baseline", "stretch"] ),
             /*
              * Align Self
              * See https://tailwindcss.com/docs/align-self
              */
-            new ClassGroup( "align-self", "self", ["auto", "start", "end", "center", "baseline", "stretch"] ),
+            ["align-self"] = new ClassGroup( "self", ["auto", "start", "end", "center", "baseline", "stretch"] ),
             /*
              * Place Content
              * See https://tailwindcss.com/docs/place-content
              */
-            new ClassGroup( "place-content", "place-content", ["baseline", .. align] ),
+            ["place-content"] = new ClassGroup( "place-content", ["baseline", .. align] ),
             /*
              * Place Items
              * See https://tailwindcss.com/docs/place-items
              */
-            new ClassGroup( "place-items", "place-items", ["start", "end", "center", "baseline", "stretch"] ),
+            ["place-items"] = new ClassGroup( "place-items", ["start", "end", "center", "baseline", "stretch"] ),
             /*
              * Place Self
              * See https://tailwindcss.com/docs/place-self
              */
-            new ClassGroup( "place-self", "place-self", ["auto", "start", "end", "center", "stretch"] ),
+            ["place-self"] = new ClassGroup( "place-self", ["auto", "start", "end", "center", "stretch"] ),
             /*
              * Padding
              * See https://tailwindcss.com/docs/padding
              */
-            new ClassGroup( "p", "p", [padding] ),
+            ["p"] = new ClassGroup( "p", [padding] ),
             /*
              * Padding X
              * See https://tailwindcss.com/docs/padding
              */
-            new ClassGroup( "px", "px", [padding] ),
+            ["px"] = new ClassGroup( "px", [padding] ),
             /*
              * Padding Y
              * See https://tailwindcss.com/docs/padding
              */
-            new ClassGroup( "py", "py", [padding] ),
+            ["py"] = new ClassGroup( "py", [padding] ),
             /*
              * Padding Start
              * See https://tailwindcss.com/docs/padding
              */
-            new ClassGroup( "ps", "ps", [padding] ),
+            ["ps"] = new ClassGroup( "ps", [padding] ),
             /*
              * Padding End
              * See https://tailwindcss.com/docs/padding
              */
-            new ClassGroup( "pe", "pe", [padding] ),
+            ["pe"] = new ClassGroup( "pe", [padding] ),
             /*
              * Padding Top
              * See https://tailwindcss.com/docs/padding
              */
-            new ClassGroup( "pt", "pt", [padding] ),
+            ["pt"] = new ClassGroup( "pt", [padding] ),
             /*
              * Padding Right
              * See https://tailwindcss.com/docs/padding
              */
-            new ClassGroup( "pr", "pr", [padding] ),
+            ["pr"] = new ClassGroup( "pr", [padding] ),
             /*
              * Padding Bottom
              * See https://tailwindcss.com/docs/padding
              */
-            new ClassGroup( "pb", "pb", [padding] ),
+            ["pb"] = new ClassGroup( "pb", [padding] ),
             /*
              * Padding Left
              * See https://tailwindcss.com/docs/padding
              */
-            new ClassGroup( "pl", "pl", [padding] ),
+            ["pl"] = new ClassGroup( "pl", [padding] ),
             /*
              * Margin
              * See https://tailwindcss.com/docs/margin
              */
-            new ClassGroup( "m", "m", [margin] ),
+            ["m"] = new ClassGroup( "m", [margin] ),
             /*
              * Margin X
              * See https://tailwindcss.com/docs/margin
              */
-            new ClassGroup( "mx", "mx", [margin] ),
+            ["mx"] = new ClassGroup( "mx", [margin] ),
             /*
              * Margin Y
              * See https://tailwindcss.com/docs/margin
              */
-            new ClassGroup( "my", "my", [margin] ),
+            ["my"] = new ClassGroup( "my", [margin] ),
             /*
              * Margin Start
              * See https://tailwindcss.com/docs/margin
              */
-            new ClassGroup( "ms", "ms", [margin] ),
+            ["ms"] = new ClassGroup( "ms", [margin] ),
             /*
              * Margin End
              * See https://tailwindcss.com/docs/margin
              */
-            new ClassGroup( "me", "me", [margin] ),
+            ["me"] = new ClassGroup( "me", [margin] ),
             /*
              * Margin Top
              * See https://tailwindcss.com/docs/margin
              */
-            new ClassGroup( "mt", "mt", [margin] ),
+            ["mt"] = new ClassGroup( "mt", [margin] ),
             /*
              * Margin Right
              * See https://tailwindcss.com/docs/margin
              */
-            new ClassGroup( "mr", "mr", [margin] ),
+            ["mr"] = new ClassGroup( "mr", [margin] ),
             /*
              * Margin Bottom
              * See https://tailwindcss.com/docs/margin
              */
-            new ClassGroup( "mb", "mb", [margin] ),
+            ["mb"] = new ClassGroup( "mb", [margin] ),
             /*
              * Margin Left
              * See https://tailwindcss.com/docs/margin
              */
-            new ClassGroup( "ml", "ml", [margin] ),
+            ["ml"] = new ClassGroup( "ml", [margin] ),
             /*
              * Space Between X
              * See https://tailwindcss.com/docs/space
              */
-            new ClassGroup( "space-x", "space-x", [space] ),
+            ["space-x"] = new ClassGroup( "space-x", [space] ),
             /*
              * Space Between X Reverse
              * See https://tailwindcss.com/docs/space
              */
-            new ClassGroup( "space-x-reverse", ["space-x-reverse"] ),
+            ["space-x-reverse"] = new ClassGroup( ["space-x-reverse"] ),
             /*
              * Space Between Y
              * See https://tailwindcss.com/docs/space
              */
-            new ClassGroup( "space-y", "space-y", [space] ),
+            ["space-y"] = new ClassGroup( "space-y", [space] ),
             /*
              * Space Between Y Reverse
              * See https://tailwindcss.com/docs/space
              */
-            new ClassGroup( "space-y-reverse", ["space-y-reverse"] ),
+            ["space-y-reverse"] = new ClassGroup( ["space-y-reverse"] ),
             /*
              * Width
              * See https://tailwindcss.com/docs/width
              */
-            new ClassGroup( "w", "w", ["auto", "min", "max", "fit", "svw", "lvw", "dvw", spacing, Validators.IsArbitraryValue] ),
+            ["w"] = new ClassGroup( "w", ["auto", "min", "max", "fit", "svw", "lvw", "dvw", spacing, Validators.IsArbitraryValue] ),
             /*
              * Min-Width
              * See https://tailwindcss.com/docs/min-width
              */
-            new ClassGroup( "min-w", "min-w", ["min", "max", "fit", spacing, Validators.IsArbitraryValue] ),
+            ["min-w"] = new ClassGroup( "min-w", ["min", "max", "fit", spacing, Validators.IsArbitraryValue] ),
             /*
              * Max-Width
              * See https://tailwindcss.com/docs/max-width
              */
-            new ClassGroup( "max-w", "max-w", ["none", "full", "min", "max", "fit", "prose", spacing, Validators.IsTshirtSize] ),
-            /*
-             * Max-Width Screen
-             * See https://tailwindcss.com/docs/max-width
-             */
-            new ClassGroup( "max-w", "max-w-screen", [Validators.IsTshirtSize] ),
+            ["max-w"] = new ClassGroup( "max-w", [
+                "none", 
+                "full", 
+                "min", 
+                "max", 
+                "fit", 
+                "prose", 
+                spacing, 
+                new ClassGroup( "screen", [Validators.IsTshirtSize] ), 
+                Validators.IsTshirtSize] ),
             /*
              * Height
              * See https://tailwindcss.com/docs/height
              */
-            new ClassGroup( "h", "h", ["auto", "min", "max", "fit", "svh", "lvh", "dvh", spacing, Validators.IsArbitraryValue] ),
+            ["h"] = new ClassGroup( "h", ["auto", "min", "max", "fit", "svh", "lvh", "dvh", spacing, Validators.IsArbitraryValue] ),
             /*
              * Min-Height
              * See https://tailwindcss.com/docs/min-height
              */
-            new ClassGroup( "min-h", "min-h", ["min", "max", "fit", "svh", "lvh", "dvh", spacing, Validators.IsArbitraryValue] ),
+            ["min-h"] = new ClassGroup( "min-h", ["min", "max", "fit", "svh", "lvh", "dvh", spacing, Validators.IsArbitraryValue] ),
             /*
              * Max-Height
              * See https://tailwindcss.com/docs/max-height
              */
-            new ClassGroup( "max-h", "max-h", ["min", "max", "fit", "svh", "lvh", "dvh", spacing, Validators.IsArbitraryValue] ),
+            ["max-h"] = new ClassGroup( "max-h", ["min", "max", "fit", "svh", "lvh", "dvh", spacing, Validators.IsArbitraryValue] ),
             /*
              * Size
              * See https://tailwindcss.com/docs/size
              */
-            new ClassGroup( "size", "size", ["auto", "min", "max", "fit", spacing, Validators.IsArbitraryValue] ),
+            ["size"] = new ClassGroup( "size", ["auto", "min", "max", "fit", spacing, Validators.IsArbitraryValue] ),
             /*
              * Font Size
              * See https://tailwindcss.com/docs/font-size
              */
-            new ClassGroup( "font-size", "text", ["base", Validators.IsTshirtSize, Validators.IsArbitraryLength] ),
+            ["font-size"] = new ClassGroup( "text", ["base", Validators.IsTshirtSize, Validators.IsArbitraryLength] ),
             /*
              * Font Smoothing
              * See https://tailwindcss.com/docs/font-smoothing
              */
-            new ClassGroup( "font-smoothing", ["antialiased", "subpixel-antialiased"] ),
+            ["font-smoothing"] = new ClassGroup( ["antialiased", "subpixel-antialiased"] ),
             /*
              * Font Style
              * See https://tailwindcss.com/docs/font-style
              */
-            new ClassGroup( "font-style", ["italic", "not-italic"] ),
+            ["font-style"] = new ClassGroup( ["italic", "not-italic"] ),
             /*
              * Font Weight
              * See https://tailwindcss.com/docs/font-weight
              */
-            new ClassGroup( "font-weight", "font", [
+            ["font-weight"] = new ClassGroup( "font", [
                 "thin",
                 "extralight",
                 "light",
@@ -773,42 +675,42 @@ public class TwMergeConfig
              * Font Family
              * See https://tailwindcss.com/docs/font-family
              */
-            new ClassGroup( "font-family", "font", any ),
+            ["font-family"] = new ClassGroup( "font", any ),
             /*
              * Font Variant Numeric
              * See https://tailwindcss.com/docs/font-variant-numeric
              */
-            new ClassGroup( "fvn-normal", ["normal-nums"] ),
+            ["fvn-normal"] = new ClassGroup( ["normal-nums"] ),
             /*
              * Font Variant Numeric
              * See https://tailwindcss.com/docs/font-variant-numeric
              */
-            new ClassGroup( "fvn-ordinal", ["ordinal"] ),
+            ["fvn-ordinal"] = new ClassGroup( ["ordinal"] ),
             /*
              * Font Variant Numeric
              * See https://tailwindcss.com/docs/font-variant-numeric
              */
-            new ClassGroup( "fvn-slashed-zero", ["slashed-zero"] ),
+            ["fvn-slashed-zero"] = new ClassGroup( ["slashed-zero"] ),
             /*
              * Font Variant Numeric
              * See https://tailwindcss.com/docs/font-variant-numeric
              */
-            new ClassGroup( "fvn-figure", ["lining-nums", "oldstyle-nums"] ),
+            ["fvn-figure"] = new ClassGroup( ["lining-nums", "oldstyle-nums"] ),
             /*
              * Font Variant Numeric
              * See https://tailwindcss.com/docs/font-variant-numeric
              */
-            new ClassGroup( "fvn-spacing", ["proportional-nums", "tabular-nums"] ),
+            ["fvn-spacing"] = new ClassGroup( ["proportional-nums", "tabular-nums"] ),
             /*
              * Font Variant Numeric
              * See https://tailwindcss.com/docs/font-variant-numeric
              */
-            new ClassGroup( "fvn-fraction", ["diagonal-fractions", "stacked-fractions"] ),
+            ["fvn-fraction"] = new ClassGroup( ["diagonal-fractions", "stacked-fractions"] ),
             /*
              * Letter Spacing
              * See https://tailwindcss.com/docs/letter-spacing
              */
-            new ClassGroup( "tracking", "tracking", [
+            ["tracking"] = new ClassGroup( "tracking", [
                 "tighter",
                 "tight",
                 "normal",
@@ -820,12 +722,12 @@ public class TwMergeConfig
              * Line Clamp
              * See https://tailwindcss.com/docs/line-clamp
              */
-            new ClassGroup( "line-clamp", "line-clamp", ["none", .. number] ),
+            ["line-clamp"] = new ClassGroup( "line-clamp", ["none", .. number] ),
             /*
              * Line Height
              * See https://tailwindcss.com/docs/line-height
              */
-            new ClassGroup( "leading", "leading", [
+            ["leading"] = new ClassGroup( "leading", [
                 "none",
                 "tight",
                 "snug",
@@ -838,82 +740,82 @@ public class TwMergeConfig
              * List Style Image
              * See https://tailwindcss.com/docs/list-style-image
              */
-            new ClassGroup( "list-image", "list-image", ["none", Validators.IsArbitraryValue] ),
+            ["list-image"] = new ClassGroup( "list-image", ["none", Validators.IsArbitraryValue] ),
             /*
              * List Style Type
              * See https://tailwindcss.com/docs/list-style-type
              */
-            new ClassGroup( "list-style-type", "list", ["none", "disc", "decimal", Validators.IsArbitraryValue] ),
+            ["list-style-type"] = new ClassGroup( "list", ["none", "disc", "decimal", Validators.IsArbitraryValue] ),
             /*
              * List Style Position
              * See https://tailwindcss.com/docs/list-style-position
              */
-            new ClassGroup( "list-style-position", "list", ["inside", "outside"] ),
+            ["list-style-position"] = new ClassGroup( "list", ["inside", "outside"] ),
             /*
              * Placeholder Color
              * See https://tailwindcss.com/docs/placeholder-color
              */
-            new ClassGroup( "placeholder-color", "placeholder", [colors] ),
+            ["placeholder-color"] = new ClassGroup( "placeholder", [colors] ),
             /*
              * Text Alignment
              * See https://tailwindcss.com/docs/text-align
              */
-            new ClassGroup( "text-alignment", "text", ["left", "center", "right", "justify", "start", "end"] ),
+            ["text-alignment"] = new ClassGroup( "text", ["left", "center", "right", "justify", "start", "end"] ),
             /*
              * Text Color
              * See https://tailwindcss.com/docs/text-color
              */
-            new ClassGroup( "text-color", "text", [colors] ),
+            ["text-color"] = new ClassGroup( "text", [colors] ),
             /*
              * Text Decoration
              * See https://tailwindcss.com/docs/text-decoration
              */
-            new ClassGroup( "text-decoration", ["underline", "overline", "line-through", "no-underline"] ),
+            ["text-decoration"] = new ClassGroup( ["underline", "overline", "line-through", "no-underline"] ),
             /*
              * Text Decoration Style
              * See https://tailwindcss.com/docs/text-decoration-style
              */
-            new ClassGroup( "text-decoration-style", "decoration", ["wavy", .. lineStyles] ),
+            ["text-decoration-style"] = new ClassGroup( "decoration", ["wavy", .. lineStyles] ),
             /*
              * Text Decoration Color
              * See https://tailwindcss.com/docs/text-decoration-color
              */
-            new ClassGroup( "text-decoration-color", "decoration", [colors] ),
+            ["text-decoration-color"] = new ClassGroup( "decoration", [colors] ),
             /*
              * Text Decoration Thickness
              * See https://tailwindcss.com/docs/text-decoration-thickness
              */
-            new ClassGroup( "text-decoration-thickness", "decoration", ["auto", "from-font", Validators.IsLength, Validators.IsArbitraryLength] ),
+            ["text-decoration-thickness"] = new ClassGroup( "decoration", ["auto", "from-font", Validators.IsLength, Validators.IsArbitraryLength] ),
             /*
              * Text Underline Offset
              * See https://tailwindcss.com/docs/text-underline-offset
              */
-            new ClassGroup( "underline-offset", "underline-offset", ["auto", Validators.IsLength, Validators.IsArbitraryValue] ),
+            ["underline-offset"] = new ClassGroup( "underline-offset", ["auto", Validators.IsLength, Validators.IsArbitraryValue] ),
             /*
              * Text Transform
              * See https://tailwindcss.com/docs/text-transform
              */
-            new ClassGroup( "text-transform", ["uppercase", "lowercase", "capitalize", "normal-case"] ),
+            ["text-transform"] = new ClassGroup( ["uppercase", "lowercase", "capitalize", "normal-case"] ),
             /*
              * Text Overflow
              * See https://tailwindcss.com/docs/text-overflow
              */
-            new ClassGroup( "text-overflow", ["truncate", "text-ellipsis", "text-clip"] ),
+            ["text-overflow"] = new ClassGroup( ["truncate", "text-ellipsis", "text-clip"] ),
             /*
              * Text Wrap
              * See https://tailwindcss.com/docs/text-wrap
              */
-            new ClassGroup( "text-wrap", "text", ["wrap", "nowrap", "balance", "pretty"] ),
+            ["text-wrap"] = new ClassGroup( "text", ["wrap", "nowrap", "balance", "pretty"] ),
             /*
              * Text Indent
              * See https://tailwindcss.com/docs/text-indent
              */
-            new ClassGroup( "indent", "indent", spacingWithArbitrary ),
+            ["indent"] = new ClassGroup( "indent", spacingWithArbitrary ),
             /*
              * Vertical Alignment
              * See https://tailwindcss.com/docs/vertical-align
              */
-            new ClassGroup( "vertical-align", "align", [
+            ["vertical-align"] = new ClassGroup( "align", [
                 "baseline",
                 "top",
                 "middle",
@@ -927,7 +829,7 @@ public class TwMergeConfig
              * Whitespace
              * See https://tailwindcss.com/docs/whitespace
              */
-            new ClassGroup( "whitespace", "whitespace", [
+            ["whitespace"] = new ClassGroup( "whitespace", [
                 "normal",
                 "nowrap",
                 "pre",
@@ -938,552 +840,547 @@ public class TwMergeConfig
              * Work Break
              * See https://tailwindcss.com/docs/word-break
              */
-            new ClassGroup( "break", "break", ["normal", "words", "all", "keep"] ),
+            ["break"] = new ClassGroup( "break", ["normal", "words", "all", "keep"] ),
             /*
              * Hyphens
              * See https://tailwindcss.com/docs/hyphens
              */
-            new ClassGroup( "hyphens", "hyphens", ["none", "manual", "auto"] ),
+            ["hyphens"] = new ClassGroup( "hyphens", ["none", "manual", "auto"] ),
             /*
              * Content
              * See https://tailwindcss.com/docs/content
              */
-            new ClassGroup( "content", "content", ["none", Validators.IsArbitraryValue] ),
+            ["content"] = new ClassGroup( "content", ["none", Validators.IsArbitraryValue] ),
             /*
              * Background Attachment
              * See https://tailwindcss.com/docs/background-attachment
              */
-            new ClassGroup( "bg-attachment", "bg", ["fixed", "local", "scroll"] ),
+            ["bg-attachment"] = new ClassGroup( "bg", ["fixed", "local", "scroll"] ),
             /*
              * Background Clip
              * See https://tailwindcss.com/docs/background-clip
              */
-            new ClassGroup( "bg-clip", "bg-clip", ["border", "padding", "content", "text"] ),
+            ["bg-clip"] = new ClassGroup( "bg-clip", ["border", "padding", "content", "text"] ),
             /*
              * Background Origin
              * See https://tailwindcss.com/docs/background-origin
              */
-            new ClassGroup( "bg-origin", "bg-origin", ["border", "padding", "content"] ),
+            ["bg-origin"] = new ClassGroup( "bg-origin", ["border", "padding", "content"] ),
             /*
              * Background Position
              * See https://tailwindcss.com/docs/background-position
              */
-            new ClassGroup( "bg-position", "bg", [.. positions, Validators.IsArbitraryPosition] ),
+            ["bg-position"] = new ClassGroup( "bg", [.. positions, Validators.IsArbitraryPosition] ),
             /*
              * Background Repeat
              * See https://tailwindcss.com/docs/background-repeat
              */
-            new ClassGroup( "bg-repeat", "bg", ["no-repeat"] ),
-            /*
-             * Background Repeat
-             * See https://tailwindcss.com/docs/background-repeat
-             */
-            new ClassGroup( "bg-repeat", "bg-repeat", ["", "x", "y", "round", "space"] ),
+            ["bg-repeat"] = new ClassGroup( "bg", [
+                "no-repeat",
+                new ClassGroup( "repeat", ["", "x", "y", "round", "space"] )] ),
             /*
              * Background Size
              * See https://tailwindcss.com/docs/background-size
              */
-            new ClassGroup( "bg-size", "bg", ["auto", "cover", "contain", Validators.IsArbitrarySize] ),
+            ["bg-size"] = new ClassGroup( "bg", ["auto", "cover", "contain", Validators.IsArbitrarySize] ),
             /*
              * Background Image
              * See https://tailwindcss.com/docs/background-image
              */
-            new ClassGroup( "bg-image", "bg", ["none", Validators.IsArbitraryImage] ),
-            /*
-             * Background Image Gradient To
-             * See https://tailwindcss.com/docs/background-image
-             */
-            new ClassGroup( "bg-image", "bg-gradient-to", ["t", "tr", "r", "br", "b", "bl", "l", "tl"] ),
+            ["bg-image"] = new ClassGroup( "bg", [
+                "none",
+                new ClassGroup( "gradient-to", ["t", "tr", "r", "br", "b", "bl", "l", "tl"] ),
+                Validators.IsArbitraryImage] ),
             /*
              * Background Color
              * See https://tailwindcss.com/docs/background-color
              */
-            new ClassGroup( "bg-color", "bg", [colors] ),
+            ["bg-color"] = new ClassGroup( "bg", [colors] ),
             /*
              * Gradient Color Stops From Position
              * See https://tailwindcss.com/docs/gradient-color-stops
              */
-            new ClassGroup( "gradient-from-pos", "from", [gradientColorStopPositions] ),
+            ["gradient-from-pos"] = new ClassGroup( "from", [gradientColorStopPositions] ),
             /*
              * Gradient Color Stops Via Position
              * See https://tailwindcss.com/docs/gradient-color-stops
              */
-            new ClassGroup( "gradient-via-pos", "via", [gradientColorStopPositions] ),
+            ["gradient-via-pos"] = new ClassGroup( "via", [gradientColorStopPositions] ),
             /*
              * Gradient Color Stops To Position
              * See https://tailwindcss.com/docs/gradient-color-stops
              */
-            new ClassGroup( "gradient-to-pos", "to", [gradientColorStopPositions] ),
+            ["gradient-to-pos"] = new ClassGroup( "to", [gradientColorStopPositions] ),
             /*
              * Gradient Color Stops From
              * See https://tailwindcss.com/docs/gradient-color-stops
              */
-            new ClassGroup( "gradient-from", "from", [gradientColorStops] ),
+            ["gradient-from"] = new ClassGroup( "from", [gradientColorStops] ),
             /*
              * Gradient Color Stops Via
              * See https://tailwindcss.com/docs/gradient-color-stops
              */
-            new ClassGroup( "gradient-via", "via", [gradientColorStops] ),
+            ["gradient-via"] = new ClassGroup( "via", [gradientColorStops] ),
             /*
              * Gradient Color Stops To
              * See https://tailwindcss.com/docs/gradient-color-stops
              */
-            new ClassGroup( "gradient-to", "to", [gradientColorStops] ),
+            ["gradient-to"] = new ClassGroup( "to", [gradientColorStops] ),
             /*
              * Border Radius
              * See https://tailwindcss.com/docs/border-radius
              */
-            new ClassGroup( "rounded", "rounded", [borderRadius] ),
+            ["rounded"] = new ClassGroup( "rounded", [borderRadius] ),
             /*
              * Border Radius Start
              * See https://tailwindcss.com/docs/border-radius
              */
-            new ClassGroup( "rounded-s", "rounded-s", [borderRadius] ),
+            ["rounded-s"] = new ClassGroup( "rounded-s", [borderRadius] ),
             /*
              * Border Radius End
              * See https://tailwindcss.com/docs/border-radius
              */
-            new ClassGroup( "rounded-e", "rounded-e", [borderRadius] ),
+            ["rounded-e"] = new ClassGroup( "rounded-e", [borderRadius] ),
             /*
              * Border Radius Top
              * See https://tailwindcss.com/docs/border-radius
              */
-            new ClassGroup( "rounded-t", "rounded-t", [borderRadius] ),
+            ["rounded-t"] = new ClassGroup( "rounded-t", [borderRadius] ),
             /*
              * Border Radius Right
              * See https://tailwindcss.com/docs/border-radius
              */
-            new ClassGroup( "rounded-r", "rounded-r", [borderRadius] ),
+            ["rounded-r"] = new ClassGroup( "rounded-r", [borderRadius] ),
             /*
              * Border Radius Bottom
              * See https://tailwindcss.com/docs/border-radius
              */
-            new ClassGroup( "rounded-b", "rounded-b", [borderRadius] ),
+            ["rounded-b"] = new ClassGroup( "rounded-b", [borderRadius] ),
             /*
              * Border Radius Left
              * See https://tailwindcss.com/docs/border-radius
              */
-            new ClassGroup( "rounded-l", "rounded-l", [borderRadius] ),
+            ["rounded-l"] = new ClassGroup( "rounded-l", [borderRadius] ),
             /*
              * Border Radius Start Start
              * See https://tailwindcss.com/docs/border-radius
              */
-            new ClassGroup( "rounded-ss", "rounded-ss", [borderRadius] ),
+            ["rounded-ss"] = new ClassGroup( "rounded-ss", [borderRadius] ),
             /*
              * Border Radius Start End
              * See https://tailwindcss.com/docs/border-radius
              */
-            new ClassGroup( "rounded-se", "rounded-se", [borderRadius] ),
+            ["rounded-se"] = new ClassGroup( "rounded-se", [borderRadius] ),
             /*
              * Border Radius End End
              * See https://tailwindcss.com/docs/border-radius
              */
-            new ClassGroup( "rounded-ee", "rounded-ee", [borderRadius] ),
+            ["rounded-ee"] = new ClassGroup( "rounded-ee", [borderRadius] ),
             /*
              * Border Radius End Start
              * See https://tailwindcss.com/docs/border-radius
              */
-            new ClassGroup( "rounded-es", "rounded-es", [borderRadius] ),
+            ["rounded-es"] = new ClassGroup( "rounded-es", [borderRadius] ),
             /*
              * Border Radius Top Left
              * See https://tailwindcss.com/docs/border-radius
              */
-            new ClassGroup( "rounded-tl", "rounded-tl", [borderRadius] ),
+            ["rounded-tl"] = new ClassGroup( "rounded-tl", [borderRadius] ),
             /*
              * Border Radius Top Right
              * See https://tailwindcss.com/docs/border-radius
              */
-            new ClassGroup( "rounded-tr", "rounded-tr", [borderRadius] ),
+            ["rounded-tr"] = new ClassGroup( "rounded-tr", [borderRadius] ),
             /*
              * Border Radius Bottom Right
              * See https://tailwindcss.com/docs/border-radius
              */
-            new ClassGroup( "rounded-br", "rounded-br", [borderRadius] ),
+            ["rounded-br"] = new ClassGroup( "rounded-br", [borderRadius] ),
             /*
              * Border Radius Bottom Left
              * See https://tailwindcss.com/docs/border-radius
              */
-            new ClassGroup( "rounded-bl", "rounded-bl", [borderRadius] ),
+            ["rounded-bl"] = new ClassGroup( "rounded-bl", [borderRadius] ),
             /*
              * Border Width
              * See https://tailwindcss.com/docs/border-width
              */
-            new ClassGroup( "border-w", "border", [borderWidth] ),
+            ["border-w"] = new ClassGroup( "border", [borderWidth] ),
             /*
              * Border Width X
              * See https://tailwindcss.com/docs/border-width
              */
-            new ClassGroup( "border-w-x", "border-x", [borderWidth] ),
+            ["border-w-x"] = new ClassGroup( "border-x", [borderWidth] ),
             /*
              * Border Width Y
              * See https://tailwindcss.com/docs/border-width
              */
-            new ClassGroup( "border-w-y", "border-y", [borderWidth] ),
+            ["border-w-y"] = new ClassGroup( "border-y", [borderWidth] ),
             /*
              * Border Width Start
              * See https://tailwindcss.com/docs/border-width
              */
-            new ClassGroup( "border-w-s", "border-s", [borderWidth] ),
+            ["border-w-s"] = new ClassGroup( "border-s", [borderWidth] ),
             /*
              * Border Width End
              * See https://tailwindcss.com/docs/border-width
              */
-            new ClassGroup( "border-w-e", "border-e", [borderWidth] ),
+            ["border-w-e"] = new ClassGroup( "border-e", [borderWidth] ),
             /*
              * Border Width Top
              * See https://tailwindcss.com/docs/border-width
              */
-            new ClassGroup( "border-w-t", "border-t", [borderWidth] ),
+            ["border-w-t"] = new ClassGroup( "border-t", [borderWidth] ),
             /*
              * Border Width Right
              * See https://tailwindcss.com/docs/border-width
              */
-            new ClassGroup( "border-w-r", "border-r", [borderWidth] ),
+            ["border-w-r"] = new ClassGroup( "border-r", [borderWidth] ),
             /*
              * Border Width Bottom
              * See https://tailwindcss.com/docs/border-width
              */
-            new ClassGroup( "border-w-b", "border-b", [borderWidth] ),
+            ["border-w-b"] = new ClassGroup( "border-b", [borderWidth] ),
             /*
              * Border Width Left
              * See https://tailwindcss.com/docs/border-width
              */
-            new ClassGroup( "border-w-l", "border-l", [borderWidth] ),
+            ["border-w-l"] = new ClassGroup( "border-l", [borderWidth] ),
             /*
              * Border Style
              * See https://tailwindcss.com/docs/border-style
              */
-            new ClassGroup( "border-style", "border", ["hidden", .. lineStyles] ),
+            ["border-style"] = new ClassGroup( "border", ["hidden", .. lineStyles] ),
             /*
              * Divide Width X
              * See https://tailwindcss.com/docs/divide-width
              */
-            new ClassGroup( "divide-x", "divide-x", [borderWidth] ),
+            ["divide-x"] = new ClassGroup( "divide-x", [borderWidth] ),
             /*
              * Divide Width X Reverse
              * See https://tailwindcss.com/docs/divide-width
              */
-            new ClassGroup( "divide-x-reverse", ["divide-x-reverse"] ),
+            ["divide-x-reverse"] = new ClassGroup( ["divide-x-reverse"] ),
             /*
              * Divide Width Y
              * See https://tailwindcss.com/docs/divide-width
              */
-            new ClassGroup( "divide-y", "divide-y", [borderWidth] ),
+            ["divide-y"] = new ClassGroup( "divide-y", [borderWidth] ),
             /*
              * Divide Width Y Reverse
              * See https://tailwindcss.com/docs/divide-width
              */
-            new ClassGroup( "divide-y-reverse", ["divide-y-reverse"] ),
+            ["divide-y-reverse"] = new ClassGroup( ["divide-y-reverse"] ),
             /*
              * Divide Style
              * See https://tailwindcss.com/docs/divide-style
              */
-            new ClassGroup( "divide-style", "divide", lineStyles ),
+            ["divide-style"] = new ClassGroup( "divide", lineStyles ),
             /*
              * Border Color
              * See https://tailwindcss.com/docs/border-color
              */
-            new ClassGroup( "border-color", "border", [borderColor] ),
+            ["border-color"] = new ClassGroup( "border", [borderColor] ),
             /*
              * Border Color X
              * See https://tailwindcss.com/docs/border-color
              */
-            new ClassGroup( "border-color-x", "border-x", [borderColor] ),
+            ["border-color-x"] = new ClassGroup( "border-x", [borderColor] ),
             /*
              * Border Color Y
              * See https://tailwindcss.com/docs/border-color
              */
-            new ClassGroup( "border-color-y", "border-y", [borderColor] ),
+            ["border-color-y"] = new ClassGroup( "border-y", [borderColor] ),
             /*
              * Border Color Top
              * See https://tailwindcss.com/docs/border-color
              */
-            new ClassGroup( "border-color-t", "border-t", [borderColor] ),
+            ["border-color-t"] = new ClassGroup( "border-t", [borderColor] ),
             /*
              * Border Color Right
              * See https://tailwindcss.com/docs/border-color
              */
-            new ClassGroup( "border-color-r", "border-r", [borderColor] ),
+            ["border-color-r"] = new ClassGroup( "border-r", [borderColor] ),
             /*
              * Border Color Bottom
              * See https://tailwindcss.com/docs/border-color
              */
-            new ClassGroup( "border-color-b", "border-b", [borderColor] ),
+            ["border-color-b"] = new ClassGroup( "border-b", [borderColor] ),
             /*
              * Border Color Left
              * See https://tailwindcss.com/docs/border-color
              */
-            new ClassGroup( "border-color-l", "border-l", [borderColor] ),
+            ["border-color-l"] = new ClassGroup( "border-l", [borderColor] ),
             /*
              * Divide Color
              * See https://tailwindcss.com/docs/divide-color
              */
-            new ClassGroup( "divide-color", "divide", [borderColor] ),
+            ["divide-color"] = new ClassGroup( "divide", [borderColor] ),
             /*
              * Outline Style
              * See https://tailwindcss.com/docs/outline-style
              */
-            new ClassGroup( "outline-style", "outline", ["", .. lineStyles] ),
+            ["outline-style"] = new ClassGroup( "outline", ["", .. lineStyles] ),
             /*
              * Outline Offset
              * See https://tailwindcss.com/docs/outline-offset
              */
-            new ClassGroup( "outline-offset", "outline-offset", [Validators.IsLength, Validators.IsArbitraryLength] ),
+            ["outline-offset"] = new ClassGroup( "outline-offset", [Validators.IsLength, Validators.IsArbitraryLength] ),
             /*
              * Outline Width
              * See https://tailwindcss.com/docs/outline-width
              */
-            new ClassGroup( "outline-w", "outline", [Validators.IsLength, Validators.IsArbitraryLength] ),
+            ["outline-w"] = new ClassGroup( "outline", [Validators.IsLength, Validators.IsArbitraryLength] ),
             /*
              * Outline Color
              * See https://tailwindcss.com/docs/outline-color
              */
-            new ClassGroup( "outline-color", "outline", [colors] ),
+            ["outline-color"] = new ClassGroup( "outline", [colors] ),
             /*
              * Ring Width
              * See https://tailwindcss.com/docs/ring-width
              */
-            new ClassGroup( "ring-w", "ring", lengthWithEmptyAndArbitrary ),
+            ["ring-w"] = new ClassGroup( "ring", lengthWithEmptyAndArbitrary ),
             /*
              * Ring Width Inset
              * See https://tailwindcss.com/docs/ring-width
              */
-            new ClassGroup( "ring-w-inset", ["ring-inset"] ),
+            ["ring-w-inset"] = new ClassGroup( ["ring-inset"] ),
             /*
              * Ring Color
              * See https://tailwindcss.com/docs/ring-color
              */
-            new ClassGroup( "ring-color", "ring", [colors] ),
+            ["ring-color"] = new ClassGroup( "ring", [colors] ),
             /*
              * Ring Offset Width
              * See https://tailwindcss.com/docs/ring-offset-width
              */
-            new ClassGroup( "ring-offset-w", "ring-offset", [Validators.IsLength, Validators.IsArbitraryLength] ),
+            ["ring-offset-w"] = new ClassGroup( "ring-offset", [Validators.IsLength, Validators.IsArbitraryLength] ),
             /*
              * Ring Offset Color
              * See https://tailwindcss.com/docs/ring-offset-color
              */
-            new ClassGroup( "ring-offset-color", "ring-offset", [colors] ),
+            ["ring-offset-color"] = new ClassGroup( "ring-offset", [colors] ),
             /*
              * Shadow
              * See https://tailwindcss.com/docs/shadow
              */
-            new ClassGroup( "shadow", "shadow", ["", "inner", "none", Validators.IsTshirtSize, Validators.IsArbitraryShadow] ),
+            ["shadow"] = new ClassGroup( "shadow", ["", "inner", "none", Validators.IsTshirtSize, Validators.IsArbitraryShadow] ),
             /*
              * Shadow Color
              * See https://tailwindcss.com/docs/shadow-color
              */
-            new ClassGroup( "shadow-color", "shadow", any ),
+            ["shadow-color"] = new ClassGroup( "shadow", any ),
             /*
              * Opacity
              * See https://tailwindcss.com/docs/opacity
              */
-            new ClassGroup( "opacity", "opacity", [opacity] ),
+            ["opacity"] = new ClassGroup( "opacity", [opacity] ),
             /*
              * Mix Blend Mode
              * See https://tailwindcss.com/docs/mix-blend-mode
              */
-            new ClassGroup( "mix-blend", "mix-blend", ["plus-lighter", "plus-darker", .. blendModes] ),
+            ["mix-blend"] = new ClassGroup( "mix-blend", ["plus-lighter", "plus-darker", .. blendModes] ),
             /*
              * Background Blend Mode
              * See https://tailwindcss.com/docs/mix-blend-mode
              */
-            new ClassGroup( "bg-blend", "bg-blend", blendModes ),
+            ["bg-blend"] = new ClassGroup( "bg-blend", blendModes ),
             /*
              * Blur
              * See https://tailwindcss.com/docs/blur
              */
-            new ClassGroup( "blur", "blur", [blur] ),
+            ["blur"] = new ClassGroup( "blur", [blur] ),
             /*
              * Brightness
              * See https://tailwindcss.com/docs/brightness
              */
-            new ClassGroup( "brightness", "brightness", [brightness] ),
+            ["brightness"] = new ClassGroup( "brightness", [brightness] ),
             /*
              * Contrast
              * See https://tailwindcss.com/docs/contrast
              */
-            new ClassGroup( "contrast", "contrast", [contrast] ),
+            ["contrast"] = new ClassGroup( "contrast", [contrast] ),
             /*
              * Drop Shadow
              * See https://tailwindcss.com/docs/drop-shadow
              */
-            new ClassGroup( "drop-shadow", "drop-shadow", ["none", "", Validators.IsTshirtSize, Validators.IsArbitraryValue] ),
+            ["drop-shadow"] = new ClassGroup( "drop-shadow", ["none", "", Validators.IsTshirtSize, Validators.IsArbitraryValue] ),
             /*
              * Grayscale
              * See https://tailwindcss.com/docs/grayscale
              */
-            new ClassGroup( "grayscale", "grayscale", [grayscale] ),
+            ["grayscale"] = new ClassGroup( "grayscale", [grayscale] ),
             /*
              * Hue Rotate
              * See https://tailwindcss.com/docs/hue-rotate
              */
-            new ClassGroup( "hue-rotate", "hue-rotate", [hueRotate] ),
+            ["hue-rotate"] = new ClassGroup( "hue-rotate", [hueRotate] ),
             /*
              * Invert
              * See https://tailwindcss.com/docs/invert
              */
-            new ClassGroup( "invert", "invert", [invert] ),
+            ["invert"] = new ClassGroup( "invert", [invert] ),
             /*
              * Saturate
              * See https://tailwindcss.com/docs/saturate
              */
-            new ClassGroup( "saturate", "saturate", [saturate] ),
+            ["saturate"] = new ClassGroup( "saturate", [saturate] ),
             /*
              * Sepia
              * See https://tailwindcss.com/docs/sepia
              */
-            new ClassGroup( "sepia", "sepia", [sepia] ),
+            ["sepia"] = new ClassGroup( "sepia", [sepia] ),
             /*
              * Backdrop Blur
              * See https://tailwindcss.com/docs/backdrop-blur
              */
-            new ClassGroup( "backdrop-blur", "backdrop-blur", [blur] ),
+            ["backdrop-blur"] = new ClassGroup( "backdrop-blur", [blur] ),
             /*
              * Backdrop Brightness
              * See https://tailwindcss.com/docs/backdrop-brightness
              */
-            new ClassGroup( "backdrop-brightness", "backdrop-brightness", [brightness] ),
+            ["backdrop-brightness"] = new ClassGroup( "backdrop-brightness", [brightness] ),
             /*
              * Backdrop Contrast
              * See https://tailwindcss.com/docs/backdrop-contrast
              */
-            new ClassGroup( "backdrop-contrast", "backdrop-contrast", [contrast] ),
+            ["backdrop-contrast"] = new ClassGroup( "backdrop-contrast", [contrast] ),
             /*
              * Backdrop Grayscale
              * See https://tailwindcss.com/docs/backdrop-grayscale
              */
-            new ClassGroup( "backdrop-grayscale", "backdrop-grayscale", [grayscale] ),
+            ["backdrop-grayscale"] = new ClassGroup( "backdrop-grayscale", [grayscale] ),
             /*
              * Backdrop Hue Rotate
              * See https://tailwindcss.com/docs/backdrop-hue-rotate
              */
-            new ClassGroup( "backdrop-hue-rotate", "backdrop-hue-rotate", [hueRotate] ),
+            ["backdrop-hue-rotate"] = new ClassGroup( "backdrop-hue-rotate", [hueRotate] ),
             /*
              * Backdrop Invert
              * See https://tailwindcss.com/docs/backdrop-invert
              */
-            new ClassGroup( "backdrop-invert", "backdrop-invert", [invert] ),
+            ["backdrop-invert"] = new ClassGroup( "backdrop-invert", [invert] ),
             /*
              * Backdrop Opacity
              * See https://tailwindcss.com/docs/backdrop-opacity
              */
-            new ClassGroup( "backdrop-opacity", "backdrop-opacity", [opacity] ),
+            ["backdrop-opacity"] = new ClassGroup( "backdrop-opacity", [opacity] ),
             /*
              * Backdrop Saturate
              * See https://tailwindcss.com/docs/backdrop-saturate
              */
-            new ClassGroup( "backdrop-saturate", "backdrop-saturate", [saturate] ),
+            ["backdrop-saturate"] = new ClassGroup( "backdrop-saturate", [saturate] ),
             /*
              * Backdrop Sepia
              * See https://tailwindcss.com/docs/backdrop-sepia
              */
-            new ClassGroup( "backdrop-sepia", "backdrop-sepia", [sepia] ),
+            ["backdrop-sepia"] = new ClassGroup( "backdrop-sepia", [sepia] ),
             /*
              * Border Collapse
              * See https://tailwindcss.com/docs/border-collapse
              */
-            new ClassGroup( "border-collapse", "border", ["collapse", "separate"] ),
+            ["border-collapse"] = new ClassGroup( "border", ["collapse", "separate"] ),
             /*
              * Border Spacing
              * See https://tailwindcss.com/docs/border-spacing
              */
-            new ClassGroup( "border-spacing", "border-spacing", [borderSpacing] ),
+            ["border-spacing"] = new ClassGroup( "border-spacing", [borderSpacing] ),
             /*
              * Border Spacing X
              * See https://tailwindcss.com/docs/border-spacing
              */
-            new ClassGroup( "border-spacing-x", "border-spacing-x", [borderSpacing] ),
+            ["border-spacing-x"] = new ClassGroup( "border-spacing-x", [borderSpacing] ),
             /*
              * Border Spacing Y
              * See https://tailwindcss.com/docs/border-spacing
              */
-            new ClassGroup( "border-spacing-y", "border-spacing-y", [borderSpacing] ),
+            ["border-spacing-y"] = new ClassGroup( "border-spacing-y", [borderSpacing] ),
             /*
              * Table Layout
              * See https://tailwindcss.com/docs/table-layout
              */
-            new ClassGroup( "table-layout", "table", ["auto", "fixed"] ),
+            ["table-layout"] = new ClassGroup( "table", ["auto", "fixed"] ),
             /*
              * Caption Side
              * See https://tailwindcss.com/docs/caption-side
              */
-            new ClassGroup( "caption", "caption", ["top", "bottom"] ),
+            ["caption"] = new ClassGroup( "caption", ["top", "bottom"] ),
             /*
              * Transition Property
              * See https://tailwindcss.com/docs/transition-property
              */
-            new ClassGroup( "transition", "transition", ["none", "all", "", "colors", "opacity", "shadow", "transform", Validators.IsArbitraryValue] ),
+            ["transition"] = new ClassGroup( "transition", ["none", "all", "", "colors", "opacity", "shadow", "transform", Validators.IsArbitraryValue] ),
             /*
              * Transition Duration
              * See https://tailwindcss.com/docs/transition-duration
              */
-            new ClassGroup( "duration", "duration", numberAndArbitrary ),
+            ["duration"] = new ClassGroup( "duration", numberAndArbitrary ),
             /*
              * Transition Timing Function
              * See https://tailwindcss.com/docs/transition-timing-function
              */
-            new ClassGroup( "ease", "ease", ["linear", "in", "out", "in-out", Validators.IsArbitraryValue] ),
+            ["ease"] = new ClassGroup( "ease", ["linear", "in", "out", "in-out", Validators.IsArbitraryValue] ),
             /*
              * Transition Delay
              * See https://tailwindcss.com/docs/transition-delay
              */
-            new ClassGroup( "delay", "delay", numberAndArbitrary ),
+            ["delay"] = new ClassGroup( "delay", numberAndArbitrary ),
             /*
              * Animation
              * See https://tailwindcss.com/docs/animation
              */
-            new ClassGroup( "animate", "animate", ["none", "spin", "ping", "pulse", "bounce", Validators.IsArbitraryValue] ),
+            ["animate"] = new ClassGroup( "animate", ["none", "spin", "ping", "pulse", "bounce", Validators.IsArbitraryValue] ),
             /*
              * Transform
              * See https://tailwindcss.com/docs/transform
              */
-            new ClassGroup( "transform", "transform", ["", "gpu", "none"] ),
+            ["transform"] = new ClassGroup( "transform", ["", "gpu", "none"] ),
             /*
              * Scale
              * See https://tailwindcss.com/docs/scale
              */
-            new ClassGroup( "scale", "scale", [scale] ),
+            ["scale"] = new ClassGroup( "scale", [scale] ),
             /*
              * Scale X
              * See https://tailwindcss.com/docs/scale
              */
-            new ClassGroup( "scale-x", "scale-x", [scale] ),
+            ["scale-x"] = new ClassGroup( "scale-x", [scale] ),
             /*
              * Scale Y
              * See https://tailwindcss.com/docs/scale
              */
-            new ClassGroup( "scale-y", "scale-y", [scale] ),
+            ["scale-y"] = new ClassGroup( "scale-y", [scale] ),
             /*
              * Rotate
              * See https://tailwindcss.com/docs/rotate
              */
-            new ClassGroup( "rotate", "rotate", [Validators.IsInteger, Validators.IsArbitraryValue] ),
+            ["rotate"] = new ClassGroup( "rotate", [Validators.IsInteger, Validators.IsArbitraryValue] ),
             /*
              * Translate X
              * See https://tailwindcss.com/docs/translate
              */
-            new ClassGroup( "translate-x", "translate-x", [translate] ),
+            ["translate-x"] = new ClassGroup( "translate-x", [translate] ),
             /*
              * Translate Y
              * See https://tailwindcss.com/docs/translate
              */
-            new ClassGroup( "translate-y", "translate-y", [translate] ),
+            ["translate-y"] = new ClassGroup( "translate-y", [translate] ),
             /*
              * Skew X
              * See https://tailwindcss.com/docs/skew
              */
-            new ClassGroup( "skew-x", "skew-x", [skew] ),
+            ["skew-x"] = new ClassGroup( "skew-x", [skew] ),
             /*
              * Skew Y
              * See https://tailwindcss.com/docs/skew
              */
-            new ClassGroup( "skew-y", "skew-y", [skew] ),
+            ["skew-y"] = new ClassGroup( "skew-y", [skew] ),
             /*
              * Transform Origin
              * See https://tailwindcss.com/docs/transform-origin
              */
-            new ClassGroup( "transform-origin", "origin", [
+            ["transform-origin"] = new ClassGroup( "origin", [
                 "center",
                 "top",
                 "top-right",
@@ -1498,17 +1395,17 @@ public class TwMergeConfig
              * Accent
              * See https://tailwindcss.com/docs/accent
              */
-            new ClassGroup( "accent", "accent", ["auto", colors] ),
+            ["accent"] = new ClassGroup( "accent", ["auto", colors] ),
             /*
              * Appearance
              * See https://tailwindcss.com/docs/appearance
              */
-            new ClassGroup( "appearance", "appearance", autoAndNone ),
+            ["appearance"] = new ClassGroup( "appearance", autoAndNone ),
             /*
              * Cursor
              * See https://tailwindcss.com/docs/cursor
              */
-            new ClassGroup( "cursor", "cursor", [
+            ["cursor"] = new ClassGroup( "cursor", [
                 "auto",
                 "default",
                 "pointer",
@@ -1550,191 +1447,293 @@ public class TwMergeConfig
              * Caret Color
              * See https://tailwindcss.com/docs/caret-color
              */
-            new ClassGroup( "caret-color", "caret", [colors] ),
+            ["caret-color"] = new ClassGroup( "caret", [colors] ),
             /*
              * Pointer Events
              * See https://tailwindcss.com/docs/pointer-events
              */
-            new ClassGroup( "pointer-events", "pointer-events", autoAndNone ),
+            ["pointer-events"] = new ClassGroup( "pointer-events", autoAndNone ),
             /*
              * Resize
              * See https://tailwindcss.com/docs/resize
              */
-            new ClassGroup( "resize", "resize", ["none", "y", "x", ""] ),
+            ["resize"] = new ClassGroup( "resize", ["none", "y", "x", ""] ),
             /*
              * Scroll Behavior
              * See https://tailwindcss.com/docs/scroll-behavior
              */
-            new ClassGroup( "scroll-behavior", "scroll", ["auto", "smooth"] ),
+            ["scroll-behavior"] = new ClassGroup( "scroll", ["auto", "smooth"] ),
             /*
              * Scroll Margin
              * See https://tailwindcss.com/docs/scroll-margin
              */
-            new ClassGroup( "scroll-m", "scroll-m", spacingWithArbitrary ),
+            ["scroll-m"] = new ClassGroup( "scroll-m", spacingWithArbitrary ),
             /*
              * Scroll Margin X
              * See https://tailwindcss.com/docs/scroll-margin
              */
-            new ClassGroup( "scroll-mx", "scroll-mx", spacingWithArbitrary ),
+            ["scroll-mx"] = new ClassGroup( "scroll-mx", spacingWithArbitrary ),
             /*
              * Scroll Margin Y
              * See https://tailwindcss.com/docs/scroll-margin
              */
-            new ClassGroup( "scroll-my", "scroll-my", spacingWithArbitrary ),
+            ["scroll-my"] = new ClassGroup( "scroll-my", spacingWithArbitrary ),
             /*
              * Scroll Margin Start
              * See https://tailwindcss.com/docs/scroll-margin
              */
-            new ClassGroup( "scroll-ms", "scroll-ms", spacingWithArbitrary ),
+            ["scroll-ms"] = new ClassGroup( "scroll-ms", spacingWithArbitrary ),
             /*
              * Scroll Margin End
              * See https://tailwindcss.com/docs/scroll-margin
              */
-            new ClassGroup( "scroll-me", "scroll-me", spacingWithArbitrary ),
+            ["scroll-me"] = new ClassGroup( "scroll-me", spacingWithArbitrary ),
             /*
              * Scroll Margin Top
              * See https://tailwindcss.com/docs/scroll-margin
              */
-            new ClassGroup( "scroll-mt", "scroll-mt", spacingWithArbitrary ),
+            ["scroll-mt"] = new ClassGroup( "scroll-mt", spacingWithArbitrary ),
             /*
              * Scroll Margin Right
              * See https://tailwindcss.com/docs/scroll-margin
              */
-            new ClassGroup( "scroll-mr", "scroll-mr", spacingWithArbitrary ),
+            ["scroll-mr"] = new ClassGroup( "scroll-mr", spacingWithArbitrary ),
             /*
              * Scroll Margin Bottom
              * See https://tailwindcss.com/docs/scroll-margin
              */
-            new ClassGroup( "scroll-mb", "scroll-mb", spacingWithArbitrary ),
+            ["scroll-mb"] = new ClassGroup( "scroll-mb", spacingWithArbitrary ),
             /*
              * Scroll Margin Left
              * See https://tailwindcss.com/docs/scroll-margin
              */
-            new ClassGroup( "scroll-ml", "scroll-ml", spacingWithArbitrary ),
+            ["scroll-ml"] = new ClassGroup( "scroll-ml", spacingWithArbitrary ),
             /*
              * Scroll Padding
              * See https://tailwindcss.com/docs/scroll-padding
              */
-            new ClassGroup( "scroll-p", "scroll-p", spacingWithArbitrary ),
+            ["scroll-p"] = new ClassGroup( "scroll-p", spacingWithArbitrary ),
             /*
              * Scroll Padding X
              * See https://tailwindcss.com/docs/scroll-padding
              */
-            new ClassGroup( "scroll-px", "scroll-px", spacingWithArbitrary ),
+            ["scroll-px"] = new ClassGroup( "scroll-px", spacingWithArbitrary ),
             /*
              * Scroll Padding Y
              * See https://tailwindcss.com/docs/scroll-padding
              */
-            new ClassGroup( "scroll-py", "scroll-py", spacingWithArbitrary ),
+            ["scroll-py"] = new ClassGroup( "scroll-py", spacingWithArbitrary ),
             /*
              * Scroll Padding Start
              * See https://tailwindcss.com/docs/scroll-padding
              */
-            new ClassGroup( "scroll-ps", "scroll-ps", spacingWithArbitrary ),
+            ["scroll-ps"] = new ClassGroup( "scroll-ps", spacingWithArbitrary ),
             /*
              * Scroll Padding End
              * See https://tailwindcss.com/docs/scroll-padding
              */
-            new ClassGroup( "scroll-pe", "scroll-pe", spacingWithArbitrary ),
+            ["scroll-pe"] = new ClassGroup( "scroll-pe", spacingWithArbitrary ),
             /*
              * Scroll Padding Top
              * See https://tailwindcss.com/docs/scroll-padding
              */
-            new ClassGroup( "scroll-pt", "scroll-pt", spacingWithArbitrary ),
+            ["scroll-pt"] = new ClassGroup( "scroll-pt", spacingWithArbitrary ),
             /*
              * Scroll Padding Right
              * See https://tailwindcss.com/docs/scroll-padding
              */
-            new ClassGroup( "scroll-pr", "scroll-pr", spacingWithArbitrary ),
+            ["scroll-pr"] = new ClassGroup( "scroll-pr", spacingWithArbitrary ),
             /*
              * Scroll Padding Bottom
              * See https://tailwindcss.com/docs/scroll-padding
              */
-            new ClassGroup( "scroll-pb", "scroll-pb", spacingWithArbitrary ),
+            ["scroll-pb"] = new ClassGroup( "scroll-pb", spacingWithArbitrary ),
             /*
              * Scroll Padding Left
              * See https://tailwindcss.com/docs/scroll-padding
              */
-            new ClassGroup( "scroll-pl", "scroll-pl", spacingWithArbitrary ),
+            ["scroll-pl"] = new ClassGroup( "scroll-pl", spacingWithArbitrary ),
             /*
              * Scroll Snap Align
              * See https://tailwindcss.com/docs/scroll-snap-align
              */
-            new ClassGroup( "snap-align", "snap", ["start", "end", "center", "align-none"] ),
+            ["snap-align"] = new ClassGroup( "snap", ["start", "end", "center", "align-none"] ),
             /*
              * Scroll Snap Stop
              * See https://tailwindcss.com/docs/scroll-snap-stop
              */
-            new ClassGroup( "snap-stop", "snap", ["normal", "always"] ),
+            ["snap-stop"] = new ClassGroup( "snap", ["normal", "always"] ),
             /*
              * Scroll Snap Type
              * See https://tailwindcss.com/docs/scroll-snap-type
              */
-            new ClassGroup( "snap-type", "snap", ["none", "x", "y", "both"] ),
+            ["snap-type"] = new ClassGroup( "snap", ["none", "x", "y", "both"] ),
             /*
              * Scroll Snap Type Strictness
              * See https://tailwindcss.com/docs/scroll-snap-type
              */
-            new ClassGroup( "snap-strictness", "snap", ["mandatory", "proximity"] ),
+            ["snap-strictness"] = new ClassGroup( "snap", ["mandatory", "proximity"] ),
             /*
              * Touch Action
              * See https://tailwindcss.com/docs/touch-action
              */
-            new ClassGroup( "touch", "touch", ["auto", "none", "manipulation"] ),
+            ["touch"] = new ClassGroup( "touch", ["auto", "none", "manipulation"] ),
             /*
              * Touch Action X
              * See https://tailwindcss.com/docs/touch-action
              */
-            new ClassGroup( "touch-x", "touch-pan", ["x", "left", "right"] ),
+            ["touch-x"] = new ClassGroup( "touch-pan", ["x", "left", "right"] ),
             /*
              * Touch Action Y
              * See https://tailwindcss.com/docs/touch-action
              */
-            new ClassGroup( "touch-y", "touch-pan", ["y", "up", "down"] ),
+            ["touch-y"] = new ClassGroup( "touch-pan", ["y", "up", "down"] ),
             /*
              * Touch Action Pinch Zoom
              * See https://tailwindcss.com/docs/touch-action
              */
-            new ClassGroup( "touch-pz", ["touch-pinch-zoom"] ),
+            ["touch-pz"] = new ClassGroup( ["touch-pinch-zoom"] ),
             /*
              * User Select
              * See https://tailwindcss.com/docs/user-select
              */
-            new ClassGroup( "select", "select", ["none", "text", "all", "auto"] ),
+            ["select"] = new ClassGroup( "select", ["none", "text", "all", "auto"] ),
             /*
              * Will Change
              * See https://tailwindcss.com/docs/will-change
              */
-            new ClassGroup( "will-change", "will-change", ["auto", "scroll", "contents", "transform", Validators.IsArbitraryValue] ),
+            ["will-change"] = new ClassGroup( "will-change", ["auto", "scroll", "contents", "transform", Validators.IsArbitraryValue] ),
             /*
              * Fill
              * See https://tailwindcss.com/docs/fill
              */
-            new ClassGroup( "fill", "fill", ["none", colors] ),
+            ["fill"] = new ClassGroup( "fill", ["none", colors] ),
             /*
              * Stroke Width
              * See https://tailwindcss.com/docs/stroke-width
              */
-            new ClassGroup( "stroke-w", "stroke", [Validators.IsLength, Validators.IsArbitraryLength, Validators.IsArbitraryNumber] ),
+            ["stroke-w"] = new ClassGroup( "stroke", [Validators.IsLength, Validators.IsArbitraryLength, Validators.IsArbitraryNumber] ),
             /*
              * Stroke
              * See https://tailwindcss.com/docs/stroke
              */
-            new ClassGroup( "stroke", "stroke", ["none", colors] ),
+            ["stroke"] = new ClassGroup( "stroke", ["none", colors] ),
             /*
              * Screen Readers
              * See https://tailwindcss.com/docs/screen-readers
              */
-            new ClassGroup( "sr", ["sr-only", "not-sr-only"] ),
+            ["sr"] = new ClassGroup( ["sr-only", "not-sr-only"] ),
             /*
              * Forced Color Adjust
              * See https://tailwindcss.com/docs/forced-color-adjust
              */
-            new ClassGroup( "forced-color-adjust", "forced-color-adjust", autoAndNone )
-        ];
+            ["forced-color-adjust"] = new ClassGroup( "forced-color-adjust", autoAndNone )
+        };
 
-        ConflictingClassGroups = _conflictingClassGroups.AsReadOnly();
-        ConflictingClassGroupModifiers = _conflictingClassGroupModifiers.AsReadOnly();
+        ConflictingClassGroups = new( 46 )
+        {
+            ["overflow"] = ["overflow-x", "overflow-y"],
+            ["overscroll"] = ["overscroll-x", "overscroll-y"],
+            ["inset"] = ["inset-x", "inset-y", "start", "end", "top", "right", "bottom", "left"],
+            ["inset-x"] = ["right", "left"],
+            ["inset-y"] = ["top", "bottom"],
+            ["flex"] = ["basis", "grow", "shrink"],
+            ["gap"] = ["gap-x", "gap-y"],
+            ["p"] = ["px", "py", "ps", "pe", "pt", "pr", "pb", "pl"],
+            ["px"] = ["pr", "pl"],
+            ["py"] = ["pt", "pb"],
+            ["m"] = ["mx", "my", "ms", "me", "mt", "mr", "mb", "ml"],
+            ["mx"] = ["mr", "ml"],
+            ["my"] = ["mt", "mb"],
+            ["size"] = ["w", "h"],
+            ["font-size"] = ["leading"],
+            ["fvn-normal"] = [
+                "fvn-ordinal",
+                "fvn-slashed-zero",
+                "fvn-figure",
+                "fvn-spacing",
+                "fvn-fraction"
+            ],
+            ["fvn-ordinal"] = ["fvn-normal"],
+            ["fvn-slashed-zero"] = ["fvn-normal"],
+            ["fvn-figure"] = ["fvn-normal"],
+            ["fvn-spacing"] = ["fvn-normal"],
+            ["fvn-fraction"] = ["fvn-normal"],
+            ["line-clamp"] = ["display", "overflow"],
+            ["rounded"] = [
+                "rounded-s",
+                "rounded-e",
+                "rounded-t",
+                "rounded-r",
+                "rounded-b",
+                "rounded-l",
+                "rounded-ss",
+                "rounded-se",
+                "rounded-ee",
+                "rounded-es",
+                "rounded-tl",
+                "rounded-tr",
+                "rounded-br",
+                "rounded-bl"
+            ],
+            ["rounded-s"] = ["rounded-ss", "rounded-es"],
+            ["rounded-e"] = ["rounded-se", "rounded-ee"],
+            ["rounded-t"] = ["rounded-tl", "rounded-tr"],
+            ["rounded-r"] = ["rounded-tr", "rounded-br"],
+            ["rounded-b"] = ["rounded-br", "rounded-bl"],
+            ["rounded-l"] = ["rounded-tl", "rounded-bl"],
+            ["border-spacing"] = ["border-spacing-x", "border-spacing-y"],
+            ["border-w"] = [
+                "border-w-s",
+                "border-w-e",
+                "border-w-t",
+                "border-w-r",
+                "border-w-b",
+                "border-w-l"
+            ],
+            ["border-w-x"] = ["border-w-r", "border-w-l"],
+            ["border-w-y"] = ["border-w-t", "border-w-b"],
+            ["border-color"] = [
+                "border-color-t",
+                "border-color-r",
+                "border-color-b",
+                "border-color-l"
+            ],
+            ["border-color-x"] = ["border-color-r", "border-color-l"],
+            ["border-color-y"] = ["border-color-t", "border-color-b"],
+            ["scroll-m"] = [
+                "scroll-mx",
+                "scroll-my",
+                "scroll-ms",
+                "scroll-me",
+                "scroll-mt",
+                "scroll-mr",
+                "scroll-mb",
+                "scroll-ml"
+            ],
+            ["scroll-mx"] = ["scroll-mr", "scroll-ml"],
+            ["scroll-my"] = ["scroll-mt", "scroll-mb"],
+            ["scroll-p"] = [
+                "scroll-px",
+                "scroll-py",
+                "scroll-ps",
+                "scroll-pe",
+                "scroll-pt",
+                "scroll-pr",
+                "scroll-pb",
+                "scroll-pl"
+            ],
+            ["scroll-px"] = ["scroll-pr", "scroll-pl"],
+            ["scroll-py"] = ["scroll-pt", "scroll-pb"],
+            ["touch"] = ["touch-x", "touch-y", "touch-pz"],
+            ["touch-x"] = ["touch"],
+            ["touch-y"] = ["touch"],
+            ["touch-pz"] = ["touch"]
+        };
+        ConflictingClassGroupModifiers = new( 1 )
+        {
+            ["font-size"] = ["leading"]
+        };
     }
 
     /// <summary>
@@ -1749,30 +1748,96 @@ public class TwMergeConfig
     /// <param name="extendedConfig">The extended configuration.</param>
     public void Extend( ExtendedConfig extendedConfig )
     {
-        if( extendedConfig.Theme is not null )
+        // Extend the theme
+        Extend( Theme, extendedConfig.Theme );
+
+        // Extend the class groups
+        ExtendClassGroups( extendedConfig.ClassGroups );
+
+        // Extend the conflicting class groups
+        Extend( ConflictingClassGroups, extendedConfig.ConflictingClassGroups );
+
+        // Extend the conflicting class group modifiers
+        Extend( ConflictingClassGroupModifiers, extendedConfig.ConflictingClassGroupModifiers );
+
+        static void Extend<T2>(
+            Dictionary<string, T2[]> originalDict,
+            Dictionary<string, T2[]>? extendDict )
         {
-            foreach( var (key, values) in extendedConfig.Theme )
+            if( extendDict is not { Count: > 0 } )
             {
-                if( Theme.TryGetValue( key, out var initialValues ) )
+                return;
+            }
+
+            foreach( var (key, values) in extendDict )
+            {
+                originalDict[key] = originalDict.TryGetValue( key, out var initialValues )
+                    ? MergeArrays( initialValues, values )
+                    : values;
+            }
+        }
+
+        static T2[] MergeArrays<T2>( T2[] array1, T2[] array2 )
+        {
+            var mergedArray = new T2[array1.Length + array2.Length];
+            array1.CopyTo( mergedArray, 0 );
+            array2.CopyTo( mergedArray, array1.Length );
+            return mergedArray;
+        }
+
+        void ExtendClassGroups( Dictionary<string, ClassGroup>? extendDict )
+        {
+            if( extendDict is not { Count: > 0 } )
+            {
+                return;
+            }
+
+            foreach( var (key, value) in extendDict )
+            {
+                if( ClassGroups.TryGetValue( key, out var existingGroup ) )
                 {
-                    Theme[key] = [.. initialValues, .. values];
+                    var mergedDefinitions = MergeArrays( existingGroup.Definitions, value.Definitions );
+                    ClassGroups[key] = new ClassGroup( value.BaseClassName, mergedDefinitions );
                 }
                 else
                 {
-                    Theme[key] = values;
+                    ClassGroups[key] = value;
                 }
             }
         }
-        if( extendedConfig.ClassGroups is { Length: > 0 } )
+    }
+
+    /// <summary>
+    /// Overrides the current configuration with the values from the provided <see cref="ExtendedConfig"/>.
+    /// </summary>
+    /// <param name="extendedConfig">The extended configuration.</param>
+    public void Override( ExtendedConfig extendedConfig )
+    {
+        // Override the theme
+        Override( Theme, extendedConfig.Theme );
+
+        // Override the class groups
+        Override( ClassGroups, extendedConfig.ClassGroups );
+
+        // Override the conflicting class groups
+        Override( ConflictingClassGroups, extendedConfig.ConflictingClassGroups );
+
+        // Override the conflicting class group modifiers
+        Override( ConflictingClassGroupModifiers, extendedConfig.ConflictingClassGroupModifiers );
+
+        static void Override<T2>(
+            Dictionary<string, T2> originalDict,
+            Dictionary<string, T2>? overrideDict )
         {
-            var classGroupsLength = ClassGroups.Length;
-            var extendedClassGroupsLength = extendedConfig.ClassGroups.Length;
-            var mergedClassGroups = new ClassGroup[classGroupsLength + extendedClassGroupsLength];
+            if( overrideDict is not { Count: > 0 } )
+            {
+                return;
+            }
 
-            Array.Copy( ClassGroups, mergedClassGroups, classGroupsLength );
-            Array.Copy( extendedConfig.ClassGroups, 0, mergedClassGroups, classGroupsLength, extendedClassGroupsLength );
-
-            ClassGroups = mergedClassGroups;
+            foreach( var (key, values) in overrideDict )
+            {
+                originalDict[key] = values;
+            }
         }
     }
 }

--- a/src/TwMergeContext.cs
+++ b/src/TwMergeContext.cs
@@ -34,12 +34,12 @@ internal partial class TwMergeContext
     {
         var conflicts = _config.ConflictingClassGroups.GetValueOrDefault( classGroupId );
 
-        if( hasPostfixModifier && _config.ConflictingClassGroupModifiers.ContainsKey( classGroupId ) )
+        if( hasPostfixModifier && 
+            _config.ConflictingClassGroupModifiers.TryGetValue( classGroupId, out var conflictingModifiers ) )
         {
             return [
                 .. conflicts,
-                .. _config.ConflictingClassGroupModifiers[classGroupId]
-            ];
+                .. conflictingModifiers];
         }
 
         return conflicts;

--- a/src/TwMergeMapFactory.cs
+++ b/src/TwMergeMapFactory.cs
@@ -1,4 +1,5 @@
-﻿using TailwindMerge.Models;
+﻿using TailwindMerge.Common;
+using TailwindMerge.Models;
 
 namespace TailwindMerge;
 
@@ -15,7 +16,8 @@ internal class TwMergeMapFactory
                 classMap,
                 classGroup.Definitions,
                 classGroup.Id,
-                classGroup.BaseClassName
+                classGroup.BaseClassName,
+                config.Theme
             );
         }
 
@@ -26,7 +28,8 @@ internal class TwMergeMapFactory
         ClassNameNode node,
         object[] definitions,
         string classGroupId,
-        string? classGroupBaseClassName )
+        string? classGroupBaseClassName,
+        Dictionary<string, object[]> theme )
     {
         var current = node;
 
@@ -51,9 +54,9 @@ internal class TwMergeMapFactory
                 current.AddValidator( validatorDefinition, classGroupId );
                 continue;
             }
-            if( definition is Func<object[]> themeGetter )
+            if( definition is ThemeGetter themeGetter )
             {
-                ProcessClassGroupsRecursively( current, themeGetter(), classGroupId, null );
+                ProcessClassGroupsRecursively( current, themeGetter( theme ), classGroupId, null, theme );
             }
         }
     }

--- a/src/TwMergeMapFactory.cs
+++ b/src/TwMergeMapFactory.cs
@@ -15,7 +15,8 @@ internal class TwMergeMapFactory
             Next = new( 155 )
         };
 
-        foreach( var (classGroupId, classGroup) in config.ClassGroups )
+        var prefixedClassGroups = GetPrefixedClassGroups( config.ClassGroups, config.Prefix );
+        foreach( var (classGroupId, classGroup) in prefixedClassGroups )
         {
             ProcessClassGroupsRecursively(
                 classMap,
@@ -29,7 +30,7 @@ internal class TwMergeMapFactory
         return classMap;
     }
 
-    internal static void ProcessClassGroupsRecursively(
+    private static void ProcessClassGroupsRecursively(
         ClassNameNode node,
         string classGroupId,
         string? classGroupBaseClassName,
@@ -70,5 +71,19 @@ internal class TwMergeMapFactory
                 ProcessClassGroupsRecursively( next, classGroupId, null, nestedClassGroup.Definitions, theme );
             }
         }
+    }
+
+    private static Dictionary<string, ClassGroup> GetPrefixedClassGroups(
+        Dictionary<string, ClassGroup> classGroups,
+        string? prefix )
+    {
+        if( string.IsNullOrEmpty( prefix ) )
+        {
+            return classGroups;
+        }
+
+        return classGroups.ToDictionary(
+            kvp => kvp.Key,
+            kvp => new ClassGroup( prefix + kvp.Value.BaseClassName, kvp.Value.Definitions ) );
     }
 }

--- a/src/TwMergeMapFactory.cs
+++ b/src/TwMergeMapFactory.cs
@@ -20,9 +20,9 @@ internal class TwMergeMapFactory
     internal static void ProcessClassGroups( ClassNameNode root, ClassGroup classGroup )
     {
         // Process standalone class groups (e.g. `display`, `container`)
-        if( string.IsNullOrEmpty( classGroup.ClassName ) )
+        if( string.IsNullOrEmpty( classGroup.BaseClassName ) )
         {
-            foreach( var item in classGroup.Items! )
+            foreach( var item in classGroup.ClassNameParts! )
             {
                 var current = root.AddNextNode( item );
                 current.ClassGroupId = classGroup.Id;
@@ -31,9 +31,9 @@ internal class TwMergeMapFactory
         // Process all other class groups
         else
         {
-            var current = root.AddNextNode( classGroup.ClassName );
+            var current = root.AddNextNode( classGroup.BaseClassName );
 
-            if( classGroup.Items is not null )
+            if( classGroup.ClassNameParts is not null )
             {
                 // Prevent class groups with common class names (e.g. `border`) 
                 // from overriding each others `ClassGroupId`.
@@ -42,7 +42,7 @@ internal class TwMergeMapFactory
                     current.ClassGroupId = classGroup.Id;
                 }
 
-                foreach( var item in classGroup.Items )
+                foreach( var item in classGroup.ClassNameParts )
                 {
                     if( !string.IsNullOrEmpty( item ) )
                     {

--- a/tests/ExtendTests.cs
+++ b/tests/ExtendTests.cs
@@ -7,8 +7,15 @@ namespace TailwindMerge.Tests;
 
 public class ExtendTests
 {
-    [Fact]
-    public void ShouldOverrideAndExtendConfigCorrectly()
+    [Theory]
+    [InlineData( "shadow-lg shadow-100 shadow-200", "shadow-lg shadow-200" )]
+    [InlineData( "custom-100 custom-200", "custom-200" )]
+    [InlineData( "text-lg text-foo", "text-foo" )]
+    [InlineData( "px-3 py-3 p-3", "py-3 p-3" )]
+    [InlineData( "p-3 px-3 py-3", "p-3 px-3 py-3" )]
+    [InlineData( "mx-2 my-2 h-2 m-2", "m-2" )]
+    [InlineData( "m-2 mx-2 my-2 h-2", "m-2 mx-2 my-2 h-2" )]
+    public void ShouldOverrideAndExtendConfigCorrectly( string classLists, string expected )
     {
         // Arrange
         var mockOptions = new Mock<IOptions<TwMergeConfig>>();
@@ -42,14 +49,10 @@ public class ExtendTests
         } );
         mockOptions.Setup( ap => ap.Value ).Returns( config );
 
-        var twMerge = new TwMerge( mockOptions.Object );
+        // Act
+        var actual = new TwMerge( mockOptions.Object ).Merge( classLists );
 
-        Assert.Equal( "shadow-lg shadow-200", twMerge.Merge( "shadow-lg shadow-100 shadow-200" ) );
-        Assert.Equal( "custom-200", twMerge.Merge( "custom-100 custom-200" ) );
-        Assert.Equal( "text-foo", twMerge.Merge( "text-lg text-foo" ) );
-        Assert.Equal( "py-3 p-3", twMerge.Merge( "px-3 py-3 p-3" ) );
-        Assert.Equal( "p-3 px-3 py-3", twMerge.Merge( "p-3 px-3 py-3" ) );
-        Assert.Equal( "m-2", twMerge.Merge( "mx-2 my-2 h-2 m-2" ) );
-        Assert.Equal( "m-2 mx-2 my-2 h-2", twMerge.Merge( "m-2 mx-2 my-2 h-2" ) );
+        // Assert
+        Assert.Equal( expected, actual );
     }
 }

--- a/tests/ExtendTests.cs
+++ b/tests/ExtendTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Options;
+
+using Moq;
+using TailwindMerge.Models;
+
+namespace TailwindMerge.Tests;
+
+public class ExtendTests
+{
+    [Fact]
+    public void ShouldOverrideAndExtendConfigCorrectly()
+    {
+        // Arrange
+        var mockOptions = new Mock<IOptions<TwMergeConfig>>();
+        var config = new TwMergeConfig();
+
+        config.Override( new ExtendedConfig()
+        {
+            ClassGroups = new()
+            {
+                ["shadow"] = new ClassGroup( "shadow", ["100", "200"] ),
+                ["customKey"] = new ClassGroup( "custom", ["100"] )
+            },
+            ConflictingClassGroups = new()
+            {
+                ["p"] = ["px"]
+            }
+        } );
+
+        config.Extend( new ExtendedConfig()
+        {
+            ClassGroups = new()
+            {
+                ["shadow"] = new ClassGroup( "shadow", ["300"] ),
+                ["customKey"] = new ClassGroup( "custom", ["200"] ),
+                ["font-size"] = new ClassGroup( "text", ["foo"] ),
+            },
+            ConflictingClassGroups = new()
+            {
+                ["m"] = ["h"],
+            }
+        } );
+        mockOptions.Setup( ap => ap.Value ).Returns( config );
+
+        var twMerge = new TwMerge( mockOptions.Object );
+
+        Assert.Equal( "shadow-lg shadow-200", twMerge.Merge( "shadow-lg shadow-100 shadow-200" ) );
+        Assert.Equal( "custom-200", twMerge.Merge( "custom-100 custom-200" ) );
+        Assert.Equal( "text-foo", twMerge.Merge( "text-lg text-foo" ) );
+        Assert.Equal( "py-3 p-3", twMerge.Merge( "px-3 py-3 p-3" ) );
+        Assert.Equal( "p-3 px-3 py-3", twMerge.Merge( "p-3 px-3 py-3" ) );
+        Assert.Equal( "m-2", twMerge.Merge( "mx-2 my-2 h-2 m-2" ) );
+        Assert.Equal( "m-2 mx-2 my-2 h-2", twMerge.Merge( "m-2 mx-2 my-2 h-2" ) );
+    }
+}

--- a/tests/PrefixTests.cs
+++ b/tests/PrefixTests.cs
@@ -23,10 +23,9 @@ public class PrefixTests
         };
 
         mockOptions.Setup( ap => ap.Value ).Returns( config );
-        var twMerge = new TwMerge( mockOptions.Object );
 
         // Act
-        var actual = new TwMerge().Merge( classLists );
+        var actual = new TwMerge( mockOptions.Object ).Merge( classLists );
 
         // Assert
         Assert.Equal( expected, actual );

--- a/tests/PrefixTests.cs
+++ b/tests/PrefixTests.cs
@@ -6,8 +6,14 @@ namespace TailwindMerge.Tests;
 
 public class PrefixTests
 {
-    [Fact]
-    public void ShouldMergeCorrectlyWithPrefix()
+    [Theory]
+    [InlineData( "tw-block tw-hidden", "tw-hidden" )]
+    [InlineData( "block hidden", "block hidden" )]
+    [InlineData( "tw-p-3 tw-p-2", "tw-p-2" )]
+    [InlineData( "p-3 p-2", "p-3 p-2" )]
+    [InlineData( "!tw-right-0 !tw-inset-0", "!tw-inset-0" )]
+    [InlineData( "hover:focus:!tw-right-0 focus:hover:!tw-inset-0", "focus:hover:!tw-inset-0" )]
+    public void ShouldMergeCorrectlyWithPrefix( string classLists, string expected )
     {
         // Arrange
         var mockOptions = new Mock<IOptions<TwMergeConfig>>();
@@ -19,14 +25,10 @@ public class PrefixTests
         mockOptions.Setup( ap => ap.Value ).Returns( config );
         var twMerge = new TwMerge( mockOptions.Object );
 
-        Assert.Equal( "tw-hidden", twMerge.Merge( "tw-block tw-hidden" ) );
-        Assert.Equal( "block hidden", twMerge.Merge( "block hidden" ) );
+        // Act
+        var actual = new TwMerge().Merge( classLists );
 
-        Assert.Equal( "tw-p-2", twMerge.Merge( "tw-p-3 tw-p-2" ) );
-        Assert.Equal( "p-3 p-2", twMerge.Merge( "p-3 p-2" ) );
-
-        Assert.Equal( "!tw-inset-0", twMerge.Merge( "!tw-right-0 !tw-inset-0" ) );
-
-        Assert.Equal( "focus:hover:!tw-inset-0", twMerge.Merge( "hover:focus:!tw-right-0 focus:hover:!tw-inset-0" ) );
+        // Assert
+        Assert.Equal( expected, actual );
     }
 }

--- a/tests/PrefixTests.cs
+++ b/tests/PrefixTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+namespace TailwindMerge.Tests;
+
+public class PrefixTests
+{
+    [Fact]
+    public void ShouldMergeCorrectlyWithPrefix()
+    {
+        // Arrange
+        var mockOptions = new Mock<IOptions<TwMergeConfig>>();
+        var config = new TwMergeConfig
+        {
+            Prefix = "tw-"
+        };
+
+        mockOptions.Setup( ap => ap.Value ).Returns( config );
+        var twMerge = new TwMerge( mockOptions.Object );
+
+        Assert.Equal( "tw-hidden", twMerge.Merge( "tw-block tw-hidden" ) );
+        Assert.Equal( "block hidden", twMerge.Merge( "block hidden" ) );
+
+        Assert.Equal( "tw-p-2", twMerge.Merge( "tw-p-3 tw-p-2" ) );
+        Assert.Equal( "p-3 p-2", twMerge.Merge( "p-3 p-2" ) );
+
+        Assert.Equal( "!tw-inset-0", twMerge.Merge( "!tw-right-0 !tw-inset-0" ) );
+
+        Assert.Equal( "focus:hover:!tw-inset-0", twMerge.Merge( "hover:focus:!tw-right-0 focus:hover:!tw-inset-0" ) );
+    }
+}

--- a/tests/SeparatorTests.cs
+++ b/tests/SeparatorTests.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+namespace TailwindMerge.Tests;
+
+public class SeparatorTests
+{
+    [Theory]
+    [InlineData( "block hidden", "hidden" )]
+    [InlineData( "p-3 p-2", "p-2" )]
+    [InlineData( "!right-0 !inset-0", "!inset-0" )]
+    [InlineData( "hover_focus_!right-0 focus_hover_!inset-0", "focus_hover_!inset-0" )]
+    [InlineData( "hover:focus:!right-0 focus:hover:!inset-0", "hover:focus:!right-0 focus:hover:!inset-0" )]
+    public void ShouldMergeCorrectlyWithSingleCharacterSeparator( string classLists, string expected )
+    {
+        // Arrange
+        var mockOptions = new Mock<IOptions<TwMergeConfig>>();
+        var config = new TwMergeConfig
+        {
+            Separator = "_"
+        };
+
+        mockOptions.Setup( ap => ap.Value ).Returns( config );
+
+        // Act
+        var actual = new TwMerge( mockOptions.Object ).Merge( classLists );
+
+        // Assert
+        Assert.Equal( expected, actual );
+    }
+
+    [Theory]
+    [InlineData( "block hidden", "hidden" )]
+    [InlineData( "p-3 p-2", "p-2" )]
+    [InlineData( "!right-0 !inset-0", "!inset-0" )]
+    [InlineData( "hover__focus__!right-0 focus__hover__!inset-0", "focus__hover__!inset-0" )]
+    [InlineData( "hover:focus:!right-0 focus:hover:!inset-0", "hover:focus:!right-0 focus:hover:!inset-0" )]
+    public void ShouldMergeCorrectlyWithMultipleCharactersSeparator( string classLists, string expected )
+    {
+        // Arrange
+        var mockOptions = new Mock<IOptions<TwMergeConfig>>();
+        var config = new TwMergeConfig
+        {
+            Separator = "__"
+        };
+
+        mockOptions.Setup( ap => ap.Value ).Returns( config );
+
+        // Act
+        var actual = new TwMerge( mockOptions.Object ).Merge( classLists );
+
+        // Assert
+        Assert.Equal( expected, actual );
+    }
+}

--- a/tests/TailwindMerge.Tests.csproj
+++ b/tests/TailwindMerge.Tests.csproj
@@ -11,6 +11,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+		<PackageReference Include="Moq" Version="4.20.70" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/ThemeTests.cs
+++ b/tests/ThemeTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Options;
+
+using Moq;
+using TailwindMerge.Models;
+
+namespace TailwindMerge.Tests;
+
+public class ThemeTests
+{
+    [Fact]
+    public void Merge_WithExtendedTheme_ShouldMergeCorrectly()
+    {
+        // Arrange
+        var mockOptions = new Mock<IOptions<TwMergeConfig>>();
+        var config = new TwMergeConfig();
+
+        config.Extend( new ExtendedConfig()
+        {
+            Theme = new()
+            {
+                ["spacing"] = ["my-space"],
+                ["margin"] = ["my-margin"]
+            }
+        } );
+        mockOptions.Setup( ap => ap.Value ).Returns( config );
+
+        var twMerge = new TwMerge( mockOptions.Object );
+
+        Assert.Equal( "p-my-space p-my-margin", twMerge.Merge( "p-3 p-my-space p-my-margin" ) );
+        Assert.Equal( "m-my-margin", twMerge.Merge( "m-3 m-my-space m-my-margin" ) );
+    }
+}

--- a/tests/ThemeTests.cs
+++ b/tests/ThemeTests.cs
@@ -44,9 +44,10 @@ public class ThemeTests
             {
                 ["my-theme"] = ["hallo", "hello"]
             },
-            ClassGroups = [
-                new ClassGroup( "px", "px", [ThemeUtility.FromTheme("my-theme")] ),
-            ]
+            ClassGroups = new()
+            {
+                ["px"] = new ClassGroup( "px", [ThemeUtility.FromTheme( "my-theme" )] ),
+            }
         } );
         mockOptions.Setup( ap => ap.Value ).Returns( config );
 

--- a/tests/ThemeTests.cs
+++ b/tests/ThemeTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Options;
 
 using Moq;
+using TailwindMerge.Common;
 using TailwindMerge.Models;
 
 namespace TailwindMerge.Tests;
@@ -8,7 +9,7 @@ namespace TailwindMerge.Tests;
 public class ThemeTests
 {
     [Fact]
-    public void Merge_WithExtendedTheme_ShouldMergeCorrectly()
+    public void Merge_WithExtendedThemeScale_ShouldMergeCorrectly()
     {
         // Arrange
         var mockOptions = new Mock<IOptions<TwMergeConfig>>();
@@ -28,5 +29,30 @@ public class ThemeTests
 
         Assert.Equal( "p-my-space p-my-margin", twMerge.Merge( "p-3 p-my-space p-my-margin" ) );
         Assert.Equal( "m-my-margin", twMerge.Merge( "m-3 m-my-space m-my-margin" ) );
+    }
+
+    [Fact]
+    public void Merge_WithExtendedThemeObject_ShouldMergeCorrectly()
+    {
+        // Arrange
+        var mockOptions = new Mock<IOptions<TwMergeConfig>>();
+        var config = new TwMergeConfig();
+
+        config.Extend( new ExtendedConfig()
+        {
+            Theme = new()
+            {
+                ["my-theme"] = ["hallo", "hello"]
+            },
+            ClassGroups = [
+                new ClassGroup( "px", "px", [ThemeUtility.FromTheme("my-theme")] ),
+            ]
+        } );
+        mockOptions.Setup( ap => ap.Value ).Returns( config );
+
+        var twMerge = new TwMerge( mockOptions.Object );
+
+        Assert.Equal( "p-3 p-hello p-hallo", twMerge.Merge( "p-3 p-hello p-hallo" ) );
+        Assert.Equal( "px-hallo", twMerge.Merge( "px-3 px-hello px-hallo" ) );
     }
 }

--- a/tests/ThemeTests.cs
+++ b/tests/ThemeTests.cs
@@ -8,8 +8,10 @@ namespace TailwindMerge.Tests;
 
 public class ThemeTests
 {
-    [Fact]
-    public void Merge_WithExtendedThemeScale_ShouldMergeCorrectly()
+    [Theory]
+    [InlineData( "p-3 p-my-space p-my-margin", "p-my-space p-my-margin" )]
+    [InlineData( "m-3 m-my-space m-my-margin", "m-my-margin" )]
+    public void Merge_WithExtendedThemeScale_ShouldMergeCorrectly( string classLists, string expected )
     {
         // Arrange
         var mockOptions = new Mock<IOptions<TwMergeConfig>>();
@@ -23,16 +25,20 @@ public class ThemeTests
                 ["margin"] = ["my-margin"]
             }
         } );
+
         mockOptions.Setup( ap => ap.Value ).Returns( config );
 
-        var twMerge = new TwMerge( mockOptions.Object );
+        // Act
+        var actual = new TwMerge( mockOptions.Object ).Merge( classLists );
 
-        Assert.Equal( "p-my-space p-my-margin", twMerge.Merge( "p-3 p-my-space p-my-margin" ) );
-        Assert.Equal( "m-my-margin", twMerge.Merge( "m-3 m-my-space m-my-margin" ) );
+        // Assert
+        Assert.Equal( expected, actual );
     }
 
-    [Fact]
-    public void Merge_WithExtendedThemeObject_ShouldMergeCorrectly()
+    [Theory]
+    [InlineData( "p-3 p-hello p-hallo", "p-3 p-hello p-hallo" )]
+    [InlineData( "px-3 px-hello px-hallo", "px-hallo" )]
+    public void Merge_WithExtendedThemeObject_ShouldMergeCorrectly( string classLists, string expected )
     {
         // Arrange
         var mockOptions = new Mock<IOptions<TwMergeConfig>>();
@@ -49,11 +55,13 @@ public class ThemeTests
                 ["px"] = new ClassGroup( "px", [ThemeUtility.FromTheme( "my-theme" )] ),
             }
         } );
+
         mockOptions.Setup( ap => ap.Value ).Returns( config );
 
-        var twMerge = new TwMerge( mockOptions.Object );
+        // Act
+        var actual = new TwMerge( mockOptions.Object ).Merge( classLists );
 
-        Assert.Equal( "p-3 p-hello p-hallo", twMerge.Merge( "p-3 p-hello p-hallo" ) );
-        Assert.Equal( "px-hallo", twMerge.Merge( "px-3 px-hello px-hallo" ) );
+        // Assert
+        Assert.Equal( expected, actual );
     }
 }


### PR DESCRIPTION
Closes #3 

Continue to expand the functionality of this package according to the [original one](https://github.com/dcastil/tailwind-merge/tree/main). 
For this PR I've added the config customization support that allows:

- Set LRU cache maximum capacity
- Set custom prefix (e.g., "_tw-_"; tw-block)
- Set custom separator (e.g., "_"; hover_bg-red-500)

**Override and/or Extend**

- Theme
- Class groups
- Conflicting class groups
- Conflicting class group modifiers

.. and all this can be done using `AddTailwindMerge` extension method that accepts a delegate of `Action<TwMergeConfig>`:

```csharp
builder.Services.AddTailwindMerge(options =>
{
    options.CacheSize = 100;
    options.Prefix = "tw-";
    options.Separator = "_";

    options.Override( new Models.ExtendedConfig()
    {
        Theme = [],
        ClassGroups = [],
        ConflictingClassGroups = [],
        ConflictingClassGroupModifiers = []
    } );

    options.Extend( new Models.ExtendedConfig()
    {
        Theme = [],
        ClassGroups = [],
        ConflictingClassGroups = [],
        ConflictingClassGroupModifiers = []
    } );
};
```

