### PR TITLE
feat(*): add support for Tailwind CSS v4.0.10

### DIFF
--- a/src/TwMergeConfig.cs
+++ b/src/TwMergeConfig.cs
@@ -117,6 +117,7 @@ public class TwMergeConfig
 		object[] gridColRowStartAndEndScale = [
 			"auto",
 			new ClassGroup( "span", ["full", V.IsInteger, V.IsArbitraryValue, V.IsArbitraryVariable] ),
+			V.IsInteger,
 			V.IsArbitraryValue,
 			V.IsArbitraryVariable
 		];

--- a/tests/TailwindCssVersionsTests.cs
+++ b/tests/TailwindCssVersionsTests.cs
@@ -82,6 +82,7 @@ public class TailwindCssVersionsTests
 	[InlineData( "field-sizing-content field-sizing-fixed", "field-sizing-fixed" )]
 	[InlineData( "scheme-normal scheme-dark", "scheme-dark" )]
 	[InlineData( "font-stretch-expanded font-stretch-[66.66%] font-stretch-50%", "font-stretch-50%" )]
+	[InlineData( "col-span-full col-2 row-span-3 row-4", "col-2 row-4" )]
 	public void Merge_TailwindCssV4Classes_MergesCorrectly( string classLists, string expected )
 	{
 		// Act


### PR DESCRIPTION
There was a new feature introduced in [Tailwind CSS v4.0.10](https://github.com/tailwindlabs/tailwindcss/releases/tag/v4.0.10):

> Add col-<number> and row-<number> utilities for grid-column and grid-row (https://github.com/tailwindlabs/tailwindcss/pull/15183)

Adding support for it here.